### PR TITLE
Exporters should no longer rely on extended_data.

### DIFF
--- a/lib/html-export/qdm-patient/qdm_patient.rb
+++ b/lib/html-export/qdm-patient/qdm_patient.rb
@@ -8,7 +8,7 @@ class QdmPatient < Mustache
     @include_style = include_style
     @patient = patient
     @qdmPatient = patient.qdmPatient
-    @insurance_provider = @patient.insurance_providers if @patientinsurance_providers
+    @insurance_provider = @patient.insurance_providers if @patient.insurance_providers
   end
 
   def include_style?

--- a/lib/qrda-export/catI-r5/qrda1_r5.rb
+++ b/lib/qrda-export/catI-r5/qrda1_r5.rb
@@ -15,7 +15,7 @@ class Qrda1R5 < Mustache
     @performance_period_start = options[:start_time]
     @performance_period_end = options[:end_time]
     @submission_program = options[:submission_program]
-    @insurance_provider = JSON.parse(@qdmPatient.extendedData.insurance_providers) if @qdmPatient.extendedData && @qdmPatient.extendedData['insurance_providers']
+    @insurance_provider = @patient.insurance_providers if @patient.insurance_providers
   end
 
   def adverse_event

--- a/lib/qrda-export/helper/patient_view_helper.rb
+++ b/lib/qrda-export/helper/patient_view_helper.rb
@@ -31,7 +31,7 @@ module Qrda
         end
 
         def mrn
-          @qdmPatient.extendedData['medical_record_number']
+          @patient.medical_record_number
         end
 
         def given_name


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
