### PR TITLE
Cat3 validation testing working with both good and bad XML files

### DIFF
--- a/test/fixtures/cat1/double_ID_test_file.xml
+++ b/test/fixtures/cat1/double_ID_test_file.xml
@@ -1,0 +1,286 @@
+<?xml version='1.0' encoding='utf-8'?>
+<?xml-stylesheet type="text/xsl" href="cda.xsl"?>
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:sdtc="urn:hl7-org:sdtc" xmlns:voc="urn:hl7-org:v3/voc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <realmCode code="US"/>
+  <typeId extension="POCD_HD000040" root="2.16.840.1.113883.1.3"/>
+  <!-- US Realm Header Template Id -->
+  <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.1.1"/>
+  <!-- QRDA Category I Framework (V3) templateId -->
+  <templateId extension="2017-08-01" root="2.16.840.1.113883.10.20.24.1.1"/>
+  <!-- QDM-based QRDA (V5) templateId -->
+  <templateId extension="2017-08-01" root="2.16.840.1.113883.10.20.24.1.2"/>
+  <!-- QRDA Category I Report - CMS (V5) templateId -->
+  <templateId extension="2018-02-01" root="2.16.840.1.113883.10.20.24.1.3"/>
+  <!-- Globally unique identifier for this QRDA document -->
+  <id root="bf676dca-fba1-4789-865c-51be40982eeb"/>
+  <!-- QRDA document type code -->
+  <code code="55182-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Measure Report"/>
+  <title>QRDA Incidence Report</title>
+  <effectiveTime value="20181116000000+0000"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <languageCode code="en"/>
+  <recordTarget>
+    <patientRole>
+      <!-- patient's PID (MRN) number -->
+      <id extension="CERN161557" root="2.16.840.1.113883.123.123.1"/>
+      <addr>
+        <streetAddressLine nullFlavor="NI"/>
+        <city nullFlavor="NI"/>
+        <state nullFlavor="NI"/>
+        <postalCode nullFlavor="NI"/>
+        <country nullFlavor="NI"/>
+      </addr>
+      <telecom nullFlavor="NI" use="HP"/>
+      <patient>
+        <name>
+          <given>p1</given>
+          <family>ECQM-4543</family>
+        </name>
+        <administrativeGenderCode nullFlavor="UNK"/>
+        <birthTime value="19821122000000"/>
+        <raceCode nullFlavor="UNK"/>
+        <ethnicGroupCode nullFlavor="UNK"/>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <author>
+    <time value="20181116000000+0000"/>
+    <assignedAuthor>
+      <id root="3d0a32f3-5164-4a6f-8922-de3badf83ddd"/>
+      <addr>
+        <streetAddressLine>2800 Rockcreek Pkwy</streetAddressLine>
+        <city>Kansas City</city>
+        <state>Missouri</state>
+        <postalCode>64117</postalCode>
+        <country>US</country>
+      </addr>
+      <telecom nullFlavor="NI" use="WP"/>
+      <assignedAuthoringDevice>
+        <manufacturerModelName>Cerner Corporation</manufacturerModelName>
+        <softwareName>Cerner Millennium</softwareName>
+      </assignedAuthoringDevice>
+    </assignedAuthor>
+  </author>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id extension="980989" root="2.16.840.1.113883.4.336"/>
+        <name>Cerner Corporation</name>
+        <telecom nullFlavor="NI" use="WP"/>
+        <addr>
+          <streetAddressLine>2800 Rockcreek Pkwy</streetAddressLine>
+          <city>Kansas City</city>
+          <state>Missouri</state>
+          <postalCode>64117</postalCode>
+          <country>US</country>
+        </addr>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <informationRecipient>
+    <intendedRecipient>
+      <id extension="HQR_IQR" root="2.16.840.1.113883.3.249.7"/>
+    </intendedRecipient>
+  </informationRecipient>
+  <legalAuthenticator>
+    <time value="20181116000000+0000"/>
+    <signatureCode code="S"/>
+    <assignedEntity>
+      <id extension="431196944" root="2.16.840.1.113883.19.5"/>
+      <addr>
+        <streetAddressLine>2800 Rockcreek Pkwy</streetAddressLine>
+        <city>Kansas City</city>
+        <state>Missouri</state>
+        <postalCode>64117</postalCode>
+        <country>US</country>
+      </addr>
+      <telecom nullFlavor="NI" use="WP"/>
+      <assignedPerson>
+        <name>
+          <given/>
+          <family/>
+        </name>
+      </assignedPerson>
+      <representedOrganization>
+        <id root="2.16.840.1.113883.19.5"/>
+        <name>Cerner Corporation</name>
+      </representedOrganization>
+    </assignedEntity>
+  </legalAuthenticator>
+  <participant typeCode="DEV">
+    <associatedEntity classCode="RGPR">
+      <id extension="980989" root="2.16.840.1.113883.3.2074.1"/>
+    </associatedEntity>
+  </participant>
+  <documentationOf typeCode="DOC">
+    <serviceEvent classCode="PCPR">
+      <effectiveTime>
+        <low value="20150401000000+0000"/>
+        <high value="20150630000000+0000"/>
+      </effectiveTime>
+      <performer typeCode="PRF">
+        <assignedEntity>
+          <!-- Provider NPI-->
+          <id nullFlavor="NA" root="2.16.840.1.113883.4.6"/>
+          <representedOrganization>
+            <!-- Organization TIN -->
+            <id extension="431196944" root="2.16.840.1.113883.4.2"/>
+          </representedOrganization>
+        </assignedEntity>
+      </performer>
+    </serviceEvent>
+  </documentationOf>
+  <component>
+    <structuredBody>
+      <component>
+        <!-- This is Measure section -->
+        <section>
+          <!-- This is the templateId for Measure Section -->
+          <templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+          <!-- This is the templateId for Measure Section QDM -->
+          <templateId root="2.16.840.1.113883.10.20.24.2.3"/>
+          <!-- This is the LOINC code for "Measure document" -->
+          <code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Measure Section</title>
+          <text/>
+          <!-- Organizers, each containing a reference to an eMeasure -->
+          <entry>
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <!-- This is the templateId for Measure Reference -->
+              <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+              <!-- This is the templateId for eMeasure Reference QDM -->
+              <templateId root="2.16.840.1.113883.10.20.24.3.97"/>
+              <id root="7d1aec63-73e0-4ea6-863c-731011779441"/>
+              <statusCode code="completed"/>
+              <!-- Containing isBranch external references -->
+              <reference typeCode="REFR">
+                <externalDocument classCode="DOC" moodCode="EVN">
+                  <!-- This is the version specific identifier for eMeasure -->
+                  <id extension="40280382-6258-7581-0162-693c3d8a07c9" root="2.16.840.1.113883.4.738"/>
+                  <id extension="0371" root="2.16.840.1.113883.5.14"/>
+                  <code code="57024-2"/>
+                  <!-- This is the title of the eMeasure -->
+                  <text>Venous Thromboembolism Prophylaxis</text>
+                </externalDocument>
+              </reference>
+            </organizer>
+          </entry>
+          <entry>
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <!-- This is the templateId for Measure Reference -->
+              <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+              <!-- This is the templateId for eMeasure Reference QDM -->
+              <templateId root="2.16.840.1.113883.10.20.24.3.97"/>
+              <id root="e691a423-ff8a-4f2f-9ab7-3799bfbf187c"/>
+              <statusCode code="completed"/>
+              <!-- Containing isBranch external references -->
+              <reference typeCode="REFR">
+                <externalDocument classCode="DOC" moodCode="EVN">
+                  <!-- This is the version specific identifier for eMeasure -->
+                  <id extension="40280382-6258-7581-0162-6931c4e6077d" root="2.16.840.1.113883.4.738"/>
+                  <id extension="0372" root="2.16.840.1.113883.5.14"/>
+                  <code code="57024-2"/>
+                  <!-- This is the title of the eMeasure -->
+                  <text>Intensive Care Unit Venous Thromboembolism Prophylaxis</text>
+                </externalDocument>
+              </reference>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+      <component>
+        <!-- This is Reporting Parameters section -->
+        <section>
+          <!-- This is the templateId for Reporting Parameters section -->
+          <templateId root="2.16.840.1.113883.10.20.17.2.1"/>
+          <templateId extension="2016-03-01" root="2.16.840.1.113883.10.20.17.2.1.1"/>
+          <code code="55187-9" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Reporting Parameters</title>
+          <text>
+            <list>
+              <item>Reporting period: 01 Jul 2018 - 30 Sep 2018</item>
+            </list>
+          </text>
+          <entry typeCode="DRIV">
+            <act classCode="ACT" moodCode="EVN">
+              <!-- Reporting Parameters Act template ID -->
+              <templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+              <templateId extension="2016-03-01" root="2.16.840.1.113883.10.20.17.3.8.1"/>
+              <id root="39f6bb02-e6e8-4627-8d06-04b3e37854a6"/>
+              <code code="252116004" codeSystem="2.16.840.1.113883.6.96" displayName="Observation Parameters"/>
+              <effectiveTime>
+                <low value="20180701"/>
+                <high value="20180930"/>
+              </effectiveTime>
+            </act>
+          </entry>
+        </section>
+      </component>
+      <component>
+        <!-- This is Patient Data section -->
+        <section>
+          <!-- This is the templateId for Patient Data section -->
+          <templateId root="2.16.840.1.113883.10.20.17.2.4"/>
+          <!-- This is the templateId for Patient Data QDM section -->
+          <templateId extension="2017-08-01" root="2.16.840.1.113883.10.20.24.2.1"/>
+          <!-- Patient Data Section QDM V3 CMS-->
+          <templateId extension="2018-02-01" root="2.16.840.1.113883.10.20.24.2.1.1"/>
+          <code code="55188-7" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Patient Data</title>
+          <text/>
+          <entry>
+            <!-- Encounter performed Act -->
+            <act classCode="ACT" moodCode="EVN">
+              <templateId extension="2017-08-01" root="2.16.840.1.113883.10.20.24.3.133"/>
+              <id extension="5583128" root="9f3923ac-49a8-452c-b35f-00083c4e4e8c"/>
+              <code code="ENC" codeSystem="2.16.840.1.113883.5.6" codeSystemName="ActClass" displayName="Encounter"/>
+              <entryRelationship typeCode="SUBJ">
+                <encounter classCode="ENC" moodCode="EVN">
+                  <!-- Encounter activities template -->
+                  <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.49"/>
+                  <!-- Encounter performed template -->
+                  <templateId extension="2017-08-01" root="2.16.840.1.113883.10.20.24.3.23"/>
+                  <id extension="5583128" root="9f3923ac-49a8-452c-b35f-00083c4e4e8c"/>
+                  <code code="8715000" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNMCT" displayName="Hospital admission, elective (procedure)" sdtc:valueSet="2.16.840.1.113883.3.666.5.307"/>
+                  <text>Encounter, Performed: Hospital admission, elective (procedure)</text>
+                  <statusCode code="completed"/>
+                  <effectiveTime>
+                    <low value="20180627135600-0500"/>
+                    <high value="20180704000000-0500"/>
+                  </effectiveTime>
+                  <!-- Facility location -->
+                  <participant typeCode="LOC">
+                    <!-- Facility Location template -->
+                    <templateId extension="2017-08-01" root="2.16.840.1.113883.10.20.24.3.100"/>
+                    <time>
+                      <low value="20180627144100-0500"/>
+                      <high value="20180627151000-0500"/>
+                    </time>
+                    <participantRole classCode="SDLOC">
+                      <code code="8715000" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNMCT" displayName="Hospital admission, elective (procedure)" sdtc:valueSet="2.16.840.1.113883.3.666.5.307"/>
+                    </participantRole>
+                  </participant>
+                </encounter>
+              </entryRelationship>
+            </act>
+          </entry>
+          <entry typeCode="DRIV">
+            <!-- Payer Information -->
+            <observation classCode="OBS" moodCode="EVN">
+              <!-- Payer Information template -->
+              <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+              <id root="35201a42-cc87-4142-807a-2d16ff62e920"/>
+              <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment source"/>
+              <statusCode code="completed"/>
+              <effectiveTime>
+                <low value="20180701000000+0000"/>
+                <high value="20180930000000+0000"/>
+              </effectiveTime>
+              <value code="9999" codeSystem="2.16.840.1.113883.3.221.5" codeSystemName="Source of Payment Typology" displayName="Unavailable / No Payer Specified / Blank" sdtc:valueSet="2.16.840.1.114222.4.11.3591" xsi:type="CD"/>
+            </observation>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/test/fixtures/cat3/qrda_cat_3_no_errors.xml
+++ b/test/fixtures/cat3/qrda_cat_3_no_errors.xml
@@ -1,0 +1,1210 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ClinicalDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xmlns="urn:hl7-org:v3"
+ xmlns:cda="urn:hl7-org:v3">
+
+  <!--
+    ********************************************************
+    CDA Header
+    ********************************************************
+  -->
+  <realmCode code="US"/>
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <!-- QRDA Category III template ID (this template ID differs from QRDA III comment only template ID). -->
+  <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
+  <id root='262b4b60-11f5-0137-96d0-320017cfe460' extension="CypressExtension"/>
+
+
+  <!-- SHALL QRDA III document type code -->
+  <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+    displayName="Quality Reporting Document Architecture Calculated Summary Report"/>
+  <!-- SHALL Title, SHOULD have this content -->
+  <title>QRDA Calculated Summary Report</title>
+  <!-- SHALL  -->
+  <effectiveTime value="20190213194032"/>
+  <confidentialityCode codeSystem="2.16.840.1.113883.5.25" code="N"/>
+  <languageCode code="en"/>
+  <!-- SHOULD The version of the file being submitted. -->
+  <versionNumber value="1"/>
+  <!-- SHALL contain recordTarget and ID - but ID is nulled to NA. This is an aggregate summary report. Therefore CDA's required patient identifier is nulled. -->
+  <recordTarget>
+    <patientRole>
+      <id nullFlavor="NA"/>
+    </patientRole>
+  </recordTarget>
+
+   <!-- SHALL have 1..* author. MAY be device or person. 
+    The author of the CDA document in this example is a device at a data submission vendor/registry. -->
+  <author>
+    <time value="20190213194032"/>
+    <assignedAuthor>
+      <!-- Registry author ID -->
+      <id root='authorRoot' extension="authorExtension"/>
+
+      
+      
+
+       <assignedAuthoringDevice>
+         <manufacturerModelName>deviceModel</manufacturerModelName>
+         <softwareName>deviceName</softwareName>
+       </assignedAuthoringDevice>
+     
+     <representedOrganization>
+  <!-- Represents unique registry organization TIN -->
+   <id root='authorsOrganizationRoot' extension="authorsOrganizationExt"/>
+
+  <!-- Contains name - specific registry not required-->
+  <name></name>
+</representedOrganization>
+
+    </assignedAuthor>
+  </author>
+
+  <!-- SHALL have 1..* author. MAY be device or person.
+    The author of the CDA document in this example is a device at a data submission vendor/registry. -->
+
+  <!-- The custodian of the CDA document is the same as the legal authenticator in this
+  example and represents the reporting organization. -->
+  <!-- SHALL -->
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+  <!-- Represents unique registry organization TIN -->
+   <id root='custodianOrganizationRoot' extension="custodianOrganizationExt"/>
+
+  <!-- Contains name - specific registry not required-->
+  <name></name>
+</representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <!-- The legal authenticator of the CDA document is a single person who is at the
+    same organization as the custodian in this example. This element must be present. -->
+  <!-- SHALL -->
+  <legalAuthenticator>
+    <!-- SHALL -->
+    <time value="20190213194032"/>
+    <!-- SHALL -->
+    <signatureCode code="S"/>
+    <assignedEntity>
+      <!-- SHALL ID -->
+      <id root='legalAuthenticatorRoot' extension="legalAuthenticatorExt"/>
+
+      
+      <assignedPerson>
+        <name>
+           <given></given>
+           <family></family>
+        </name>
+     </assignedPerson>
+
+      <representedOrganization>
+  <!-- Represents unique registry organization TIN -->
+   <id root='legalAuthenticatorOrgRoot' extension="legalAuthenticatorOrgExt"/>
+
+  <!-- Contains name - specific registry not required-->
+  <name></name>
+</representedOrganization>
+    </assignedEntity>
+  </legalAuthenticator>
+
+  <documentationOf typeCode="DOC">
+  <serviceEvent classCode="PCPR"> <!-- care provision -->
+    <!-- No provider data found in the patient record
+         putting in a fake provider -->
+    <effectiveTime>
+      <low value="20020716"/>
+      <high value="20190213194032"/>
+    </effectiveTime>
+    <!-- You can include multiple performers, each with an NPI, TIN, CCN. -->
+    <performer typeCode="PRF">
+      <time>
+        <low value="20020716"/>
+        <high value="20190213194032"/>
+      </time>
+      <assignedEntity>
+        <!-- This is the provider NPI -->
+        <id root="2.16.840.1.113883.4.6" extension="111111111" />
+        <representedOrganization>
+          <!-- This is the organization TIN -->
+          <id root="2.16.840.1.113883.4.2" extension="1234567" />
+          <!-- This is the organization CCN -->
+          <id root="2.16.840.1.113883.4.336" extension="54321" />
+        </representedOrganization>
+      </assignedEntity>
+    </performer>
+  </serviceEvent>
+</documentationOf>
+
+
+
+  <!--
+********************************************************
+CDA Body
+********************************************************
+-->
+  <component>
+    <structuredBody>
+      <!--
+********************************************************
+QRDA Category III Reporting Parameters
+********************************************************
+-->
+      <component>
+        <section>
+          <!-- This is the templateId for Reporting Parameters section -->
+          <templateId root="2.16.840.1.113883.10.20.17.2.1"/>
+
+          <!-- This is the templateId for the QRDA III Reporting Parameters Section -->
+          <templateId root="2.16.840.1.113883.10.20.27.2.2"/>
+
+          <code code="55187-9" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Reporting Parameters</title>
+          <text>
+            <list>
+              <item>Reporting period: January 1st, 2017 00:00 - December 31st, 2017 23:59</item>
+            </list>
+          </text>
+          <entry typeCode="DRIV">
+                      <act classCode="ACT" moodCode="EVN">
+              <!-- This is the templateId for Reporting Parameters Act -->
+              <templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+              <id extension="F79FD35B8E3CD0C5DE2DB8871D4A6BFE" />
+              <code code="252116004" codeSystem="2.16.840.1.113883.6.96" displayName="Observation Parameters"/>
+              <effectiveTime>
+                <low value="20170101000000"/>
+                <high value="20171231235959"/>
+              </effectiveTime>
+            </act>
+          </entry>
+        </section>
+      </component>
+      <!--
+********************************************************
+Measure Section
+********************************************************
+-->
+      <component>
+        <section>
+          <!-- Implied template Measure Section templateId -->
+          <templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+          <!-- In this case the query is using an eMeasure -->
+          <!-- QRDA Category III Measure Section template -->
+          <templateId root="2.16.840.1.113883.10.20.27.2.1" extension="2017-06-01"/>
+          <code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Measure Section</title>
+          <text>
+
+          </text>
+          <entry>
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <!-- Implied template Measure Reference templateId -->
+              <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+              <!-- SHALL 1..* (one for each referenced measure) Measure Reference and Results template -->
+              <templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
+              <id extension="40280382-6258-7581-0162-974E086F181E"/>
+              <statusCode code="completed"/>
+              <reference typeCode="REFR">
+                <externalDocument classCode="DOC" moodCode="EVN">
+                  <!-- SHALL: required Id but not restricted to the eMeasure Document/Id-->
+                  <!-- QualityMeasureDocument/id This is the version specific identifier for eMeasure -->
+                  <id root="2.16.840.1.113883.4.738" extension="40280382-6258-7581-0162-974E086F181E"/>
+
+                  <!-- SHOULD This is the title of the eMeasure -->
+                  <text>Maternal Depression Screening</text>
+                  <!-- SHOULD: setId is the eMeasure version neutral id  -->
+                  <setId root="8E6C8479-99FD-4949-B0AD-24FA60FE4201"/>
+                  <!-- This is the sequential eMeasure Version number -->
+                  <versionNumber value="1"/>
+                </externalDocument>
+              </reference>
+
+              <component>
+              <observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
+  <code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+    displayName="Performance Rate" 
+    codeSystemName="2.16.840.1.113883.6.1"/>
+  <statusCode code="completed"/>
+  <value xsi:type="REAL" value="0.4"/>
+  <reference typeCode="REFR">
+     <externalObservation classCode="OBS" moodCode="EVN">
+       <id root="8E82739E-EE2A-4FA3-8593-01754A177BAB"/>
+       <code code="NUMER" displayName="Numerator" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ObservationValue"/>
+    </externalObservation>
+  </reference>
+</observation>
+
+              </component>
+              <component>
+              
+<!--   MEASURE DATA REPORTING FOR    IPP  0ABD1F84-09B1-421D-BE08-10F3B2413456  -->
+<observation classCode="OBS" moodCode="EVN">
+  <!-- Measure Data template -->
+  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+  <code code="ASSERTION" 
+        codeSystem="2.16.840.1.113883.5.4" 
+        displayName="Assertion" 
+        codeSystemName="ActCode"/>
+  <statusCode code="completed"/>
+  <value xsi:type="CD" code="IPOP"
+         codeSystem="2.16.840.1.113883.5.4"  
+         codeSystemName="ActCode"/>
+  <!-- Aggregate Count -->
+  <entryRelationship typeCode="SUBJ" inversionInd="true">
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+      <code code="MSRAGG" 
+        displayName="rate aggregation" 
+        codeSystem="2.16.840.1.113883.5.4" 
+        codeSystemName="ActCode"/>
+      <value xsi:type="INT" value="4"/>
+      <methodCode code="COUNT" 
+        displayName="Count" 
+        codeSystem="2.16.840.1.113883.5.84" 
+        codeSystemName="ObservationMethod"/>
+    </observation>
+  </entryRelationship>
+   
+   <!--    SEX Supplemental Data Reporting for IPP  0ABD1F84-09B1-421D-BE08-10F3B2413456      --> 
+         
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Sex Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="76689-9" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="F"
+             codeSystem="2.16.840.1.113883.5.1"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+   
+   <!--    SEX Supplemental Data Reporting for IPP  0ABD1F84-09B1-421D-BE08-10F3B2413456      --> 
+         
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Sex Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="76689-9" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="M"
+             codeSystem="2.16.840.1.113883.5.1"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="3"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+    <!--     ETHNICITY Supplemental Data Reporting  for IPP  0ABD1F84-09B1-421D-BE08-10F3B2413456     --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Ethnicity Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="69490-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2186-5"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="3"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+    <!--     ETHNICITY Supplemental Data Reporting  for IPP  0ABD1F84-09B1-421D-BE08-10F3B2413456     --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Ethnicity Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="69490-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2135-2"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+   <!--      RACE Supplemental Data Reporting  for IPP  0ABD1F84-09B1-421D-BE08-10F3B2413456 --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Race Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="72826-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="1002-5"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+   <!--      RACE Supplemental Data Reporting  for IPP  0ABD1F84-09B1-421D-BE08-10F3B2413456 --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Race Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="72826-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2028-9"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+   <!--      RACE Supplemental Data Reporting  for IPP  0ABD1F84-09B1-421D-BE08-10F3B2413456 --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Race Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="72826-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2054-5"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="1"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+ <!--         PAYER Supplemental Data Reporting   for IPP  0ABD1F84-09B1-421D-BE08-10F3B2413456   -->
+   <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Payer Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+        <id nullFlavor="NA" />
+      <code code="48768-6" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2"
+             codeSystem="2.16.840.1.113883.3.221.5"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+ <!--         PAYER Supplemental Data Reporting   for IPP  0ABD1F84-09B1-421D-BE08-10F3B2413456   -->
+   <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Payer Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+        <id nullFlavor="NA" />
+      <code code="48768-6" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="349"
+             codeSystem="2.16.840.1.113883.3.221.5"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="3"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+  <reference typeCode="REFR">
+     <externalObservation classCode="OBS" moodCode="EVN">
+        <id root="0ABD1F84-09B1-421D-BE08-10F3B2413456"/>
+     </externalObservation>
+  </reference>
+</observation>
+              </component>
+              <component>
+              
+<!--   MEASURE DATA REPORTING FOR    DENOM  B484793F-FF58-49CD-9F29-289B5246BF22  -->
+<observation classCode="OBS" moodCode="EVN">
+  <!-- Measure Data template -->
+  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+  <code code="ASSERTION" 
+        codeSystem="2.16.840.1.113883.5.4" 
+        displayName="Assertion" 
+        codeSystemName="ActCode"/>
+  <statusCode code="completed"/>
+  <value xsi:type="CD" code="DENOM"
+         codeSystem="2.16.840.1.113883.5.4"  
+         codeSystemName="ActCode"/>
+  <!-- Aggregate Count -->
+  <entryRelationship typeCode="SUBJ" inversionInd="true">
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+      <code code="MSRAGG" 
+        displayName="rate aggregation" 
+        codeSystem="2.16.840.1.113883.5.4" 
+        codeSystemName="ActCode"/>
+      <value xsi:type="INT" value="5"/>
+      <methodCode code="COUNT" 
+        displayName="Count" 
+        codeSystem="2.16.840.1.113883.5.84" 
+        codeSystemName="ObservationMethod"/>
+    </observation>
+  </entryRelationship>
+   
+   <!--    SEX Supplemental Data Reporting for DENOM  B484793F-FF58-49CD-9F29-289B5246BF22      --> 
+         
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Sex Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="76689-9" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="F"
+             codeSystem="2.16.840.1.113883.5.1"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+   
+   <!--    SEX Supplemental Data Reporting for DENOM  B484793F-FF58-49CD-9F29-289B5246BF22      --> 
+         
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Sex Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="76689-9" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="M"
+             codeSystem="2.16.840.1.113883.5.1"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="3"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+    <!--     ETHNICITY Supplemental Data Reporting  for DENOM  B484793F-FF58-49CD-9F29-289B5246BF22     --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Ethnicity Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="69490-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2186-5"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="3"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+    <!--     ETHNICITY Supplemental Data Reporting  for DENOM  B484793F-FF58-49CD-9F29-289B5246BF22     --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Ethnicity Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="69490-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2135-2"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+   <!--      RACE Supplemental Data Reporting  for DENOM  B484793F-FF58-49CD-9F29-289B5246BF22 --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Race Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="72826-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="1002-5"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+   <!--      RACE Supplemental Data Reporting  for DENOM  B484793F-FF58-49CD-9F29-289B5246BF22 --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Race Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="72826-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2028-9"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+   <!--      RACE Supplemental Data Reporting  for DENOM  B484793F-FF58-49CD-9F29-289B5246BF22 --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Race Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="72826-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2054-5"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="1"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+ <!--         PAYER Supplemental Data Reporting   for DENOM  B484793F-FF58-49CD-9F29-289B5246BF22   -->
+   <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Payer Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+        <id nullFlavor="NA" />
+      <code code="48768-6" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2"
+             codeSystem="2.16.840.1.113883.3.221.5"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+ <!--         PAYER Supplemental Data Reporting   for DENOM  B484793F-FF58-49CD-9F29-289B5246BF22   -->
+   <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Payer Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+        <id nullFlavor="NA" />
+      <code code="48768-6" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="349"
+             codeSystem="2.16.840.1.113883.3.221.5"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="3"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+  <reference typeCode="REFR">
+     <externalObservation classCode="OBS" moodCode="EVN">
+        <id root="B484793F-FF58-49CD-9F29-289B5246BF22"/>
+     </externalObservation>
+  </reference>
+</observation>
+              </component>
+              <component>
+              
+<!--   MEASURE DATA REPORTING FOR    NUMER  8E82739E-EE2A-4FA3-8593-01754A177BAB  -->
+<observation classCode="OBS" moodCode="EVN">
+  <!-- Measure Data template -->
+  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+  <code code="ASSERTION" 
+        codeSystem="2.16.840.1.113883.5.4" 
+        displayName="Assertion" 
+        codeSystemName="ActCode"/>
+  <statusCode code="completed"/>
+  <value xsi:type="CD" code="NUMER"
+         codeSystem="2.16.840.1.113883.5.4"  
+         codeSystemName="ActCode"/>
+  <!-- Aggregate Count -->
+  <entryRelationship typeCode="SUBJ" inversionInd="true">
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+      <code code="MSRAGG" 
+        displayName="rate aggregation" 
+        codeSystem="2.16.840.1.113883.5.4" 
+        codeSystemName="ActCode"/>
+      <value xsi:type="INT" value="2"/>
+      <methodCode code="COUNT" 
+        displayName="Count" 
+        codeSystem="2.16.840.1.113883.5.84" 
+        codeSystemName="ObservationMethod"/>
+    </observation>
+  </entryRelationship>
+   
+   <!--    SEX Supplemental Data Reporting for NUMER  8E82739E-EE2A-4FA3-8593-01754A177BAB      --> 
+         
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Sex Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="76689-9" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="F"
+             codeSystem="2.16.840.1.113883.5.1"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="1"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+   
+   <!--    SEX Supplemental Data Reporting for NUMER  8E82739E-EE2A-4FA3-8593-01754A177BAB      --> 
+         
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Sex Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="76689-9" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="M"
+             codeSystem="2.16.840.1.113883.5.1"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="1"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+    <!--     ETHNICITY Supplemental Data Reporting  for NUMER  8E82739E-EE2A-4FA3-8593-01754A177BAB     --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Ethnicity Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="69490-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2186-5"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="1"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+    <!--     ETHNICITY Supplemental Data Reporting  for NUMER  8E82739E-EE2A-4FA3-8593-01754A177BAB     --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Ethnicity Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="69490-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2135-2"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="1"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+   <!--      RACE Supplemental Data Reporting  for NUMER  8E82739E-EE2A-4FA3-8593-01754A177BAB --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Race Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="72826-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="1002-5"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="1"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+   <!--      RACE Supplemental Data Reporting  for NUMER  8E82739E-EE2A-4FA3-8593-01754A177BAB --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Race Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="72826-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2028-9"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="1"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+ <!--         PAYER Supplemental Data Reporting   for NUMER  8E82739E-EE2A-4FA3-8593-01754A177BAB   -->
+   <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Payer Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+        <id nullFlavor="NA" />
+      <code code="48768-6" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="349"
+             codeSystem="2.16.840.1.113883.3.221.5"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+  <reference typeCode="REFR">
+     <externalObservation classCode="OBS" moodCode="EVN">
+        <id root="8E82739E-EE2A-4FA3-8593-01754A177BAB"/>
+     </externalObservation>
+  </reference>
+</observation>
+              </component>
+            </organizer>
+          </entry>
+          <entry>
+                      <act classCode="ACT" moodCode="EVN">
+              <!-- This is the templateId for Reporting Parameters Act -->
+              <templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+              <id extension="F79FD35B8E3CD0C5DE2DB8871D4A6BFE" />
+              <code code="252116004" codeSystem="2.16.840.1.113883.6.96" displayName="Observation Parameters"/>
+              <effectiveTime>
+                <low value="20170101000000"/>
+                <high value="20171231235959"/>
+              </effectiveTime>
+            </act>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/test/fixtures/cat3/qrda_cat_3_with_errors.xml
+++ b/test/fixtures/cat3/qrda_cat_3_with_errors.xml
@@ -1,0 +1,1210 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ClinicalDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xmlns="urn:hl7-org:v3"
+ xmlns:cda="urn:hl7-org:v3">
+
+  <!--
+    ********************************************************
+    CDA Header
+    ********************************************************
+  -->
+  <realmCode code="USA"/>
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <!-- QRDA Category III template ID (this template ID differs from QRDA III comment only template ID). -->
+  <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
+  <id root='262b4b60-11f5-0137-96d0-320017cfe460' extension="CypressExtension"/>
+
+
+  <!-- SHALL QRDA III document type code -->
+  <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+    displayName="Quality Reporting Document Architecture Calculated Summary Report"/>
+  <!-- SHALL Title, SHOULD have this content -->
+  <title>QRDA Calculated Summary Report</title>
+  <!-- SHALL  -->
+  <effectiveTime value="20190213194032"/>
+  <confidentialityCode codeSystem="2.16.840.1.113883.5.25" code="N"/>
+  <languageCode code="en"/>
+  <!-- SHOULD The version of the file being submitted. -->
+  <versionNumber value="1"/>
+  <!-- SHALL contain recordTarget and ID - but ID is nulled to NA. This is an aggregate summary report. Therefore CDA's required patient identifier is nulled. -->
+  <recordTarget>
+    <patientRole>
+      <id nullFlavor="NA"/>
+    </patientRole>
+  </recordTarget>
+
+   <!-- SHALL have 1..* author. MAY be device or person. 
+    The author of the CDA document in this example is a device at a data submission vendor/registry. -->
+  <author>
+    <time value="20190213194032"/>
+    <assignedAuthor>
+      <!-- Registry author ID -->
+      <id root='authorRoot' extension="authorExtension"/>
+
+      
+      
+
+       <assignedAuthoringDevice>
+         <manufacturerModelName>deviceModel</manufacturerModelName>
+         <softwareName>deviceName</softwareName>
+       </assignedAuthoringDevice>
+     
+     <representedOrganization>
+  <!-- Represents unique registry organization TIN -->
+   <id root='authorsOrganizationRoot' extension="authorsOrganizationExt"/>
+
+  <!-- Contains name - specific registry not required-->
+  <name></name>
+</representedOrganization>
+
+    </assignedAuthor>
+  </author>
+
+  <!-- SHALL have 1..* author. MAY be device or person.
+    The author of the CDA document in this example is a device at a data submission vendor/registry. -->
+
+  <!-- The custodian of the CDA document is the same as the legal authenticator in this
+  example and represents the reporting organization. -->
+  <!-- SHALL -->
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+  <!-- Represents unique registry organization TIN -->
+   <id root='custodianOrganizationRoot' extension="custodianOrganizationExt"/>
+
+  <!-- Contains name - specific registry not required-->
+  <name></name>
+</representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <!-- The legal authenticator of the CDA document is a single person who is at the
+    same organization as the custodian in this example. This element must be present. -->
+  <!-- SHALL -->
+  <legalAuthenticator>
+    <!-- SHALL -->
+    <time value="20190213194032"/>
+    <!-- SHALL -->
+    <signatureCode code="S"/>
+    <assignedEntity>
+      <!-- SHALL ID -->
+      <id root='legalAuthenticatorRoot' extension="legalAuthenticatorExt"/>
+
+      
+      <assignedPerson>
+        <name>
+           <given></given>
+           <family></family>
+        </name>
+     </assignedPerson>
+
+      <representedOrganization>
+  <!-- Represents unique registry organization TIN -->
+   <id root='legalAuthenticatorOrgRoot' extension="legalAuthenticatorOrgExt"/>
+
+  <!-- Contains name - specific registry not required-->
+  <name></name>
+</representedOrganization>
+    </assignedEntity>
+  </legalAuthenticator>
+
+  <documentationOf typeCode="DOC">
+  <serviceEvent classCode="PCPR"> <!-- care provision -->
+    <!-- No provider data found in the patient record
+         putting in a fake provider -->
+    <effectiveTime>
+      <low value="20020716"/>
+      <high value="20190213194032"/>
+    </effectiveTime>
+    <!-- You can include multiple performers, each with an NPI, TIN, CCN. -->
+    <performer typeCode="PRF">
+      <time>
+        <low value="20020716"/>
+        <high value="20190213194032"/>
+      </time>
+      <assignedEntity>
+        <!-- This is the provider NPI -->
+        <id root="2.16.840.1.113883.4.6" extension="111111111" />
+        <representedOrganization>
+          <!-- This is the organization TIN -->
+          <id root="2.16.840.1.113883.4.2" extension="1234567" />
+          <!-- This is the organization CCN -->
+          <id root="2.16.840.1.113883.4.336" extension="54321" />
+        </representedOrganization>
+      </assignedEntity>
+    </performer>
+  </serviceEvent>
+</documentationOf>
+
+
+
+  <!--
+********************************************************
+CDA Body
+********************************************************
+-->
+  <component>
+    <structuredBody>
+      <!--
+********************************************************
+QRDA Category III Reporting Parameters
+********************************************************
+-->
+      <component>
+        <section>
+          <!-- This is the templateId for Reporting Parameters section -->
+          <templateId root="2.16.840.1.113883.10.20.17.2.1"/>
+
+          <!-- This is the templateId for the QRDA III Reporting Parameters Section -->
+          <templateId root="2.16.840.1.113883.10.20.27.2.2"/>
+
+          <code code="55187-9" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Reporting Parameters</title>
+          <text>
+            <list>
+              <item>Reporting period: January 1st, 2017 00:00 - December 31st, 2017 23:59</item>
+            </list>
+          </text>
+          <entry typeCode="DRIV">
+                      <act classCode="ACT" moodCode="EVN">
+              <!-- This is the templateId for Reporting Parameters Act -->
+              <templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+              <id extension="F79FD35B8E3CD0C5DE2DB8871D4A6BFE" />
+              <code code="252116004" codeSystem="2.16.840.1.113883.6.96" displayName="Observation Parameters"/>
+              <effectiveTime>
+                <low value="20170101000000"/>
+                <high value="20171231235959"/>
+              </effectiveTime>
+            </act>
+          </entry>
+        </section>
+      </component>
+      <!--
+********************************************************
+Measure Section
+********************************************************
+-->
+      <component>
+        <section>
+          <!-- Implied template Measure Section templateId -->
+          <templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+          <!-- In this case the query is using an eMeasure -->
+          <!-- QRDA Category III Measure Section template -->
+          <templateId root="2.16.840.1.113883.10.20.27.2.1" extension="2017-06-01"/>
+          <code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Measure Section</title>
+          <text>
+
+          </text>
+          <entry>
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <!-- Implied template Measure Reference templateId -->
+              <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+              <!-- SHALL 1..* (one for each referenced measure) Measure Reference and Results template -->
+              <templateId root="2.16.840.1.113883.10.20.27.3.1" extension="2016-09-01"/>
+              <id extension="40280382-6258-7581-0162-974E086F181E"/>
+              <statusCode code="completed"/>
+              <reference typeCode="REFR">
+                <externalDocument classCode="DOC" moodCode="EVN">
+                  <!-- SHALL: required Id but not restricted to the eMeasure Document/Id-->
+                  <!-- QualityMeasureDocument/id This is the version specific identifier for eMeasure -->
+                  <id root="2.16.840.1.113883.4.738" extension="40280382-6258-7581-0162-974E086F181E"/>
+
+                  <!-- SHOULD This is the title of the eMeasure -->
+                  <text>Maternal Depression Screening</text>
+                  <!-- SHOULD: setId is the eMeasure version neutral id  -->
+                  <setId root="8E6C8479-99FD-4949-B0AD-24FA60FE4201"/>
+                  <!-- This is the sequential eMeasure Version number -->
+                  <versionNumber value="1"/>
+                </externalDocument>
+              </reference>
+
+              <component>
+              <observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.27.3.14" extension="2016-09-01"/>
+  <templateId root="2.16.840.1.113883.10.20.27.3.30" extension="2016-09-01"/>
+  <code code="72510-1" codeSystem="2.16.840.1.113883.6.1"
+    displayName="Performance Rate" 
+    codeSystemName="2.16.840.1.113883.6.1"/>
+  <statusCode code="completed"/>
+  <value xsi:type="REAL" value="0.4"/>
+  <reference typeCode="REFR">
+     <externalObservation classCode="OBS" moodCode="EVN">
+       <id root="8E82739E-EE2A-4FA3-8593-01754A177BAB"/>
+       <code code="NUMER" displayName="Numerator" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ObservationValue"/>
+    </externalObservation>
+  </reference>
+</observation>
+
+              </component>
+              <component>
+              
+<!--   MEASURE DATA REPORTING FOR    IPP  0ABD1F84-09B1-421D-BE08-10F3B2413456  -->
+<observation classCode="OBS" moodCode="EVN">
+  <!-- Measure Data template -->
+  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+  <code code="ASSERTION" 
+        codeSystem="2.16.840.1.113883.5.4" 
+        displayName="Assertion" 
+        codeSystemName="ActCode"/>
+  <statusCode code="completed"/>
+  <value xsi:type="CD" code="IPOP"
+         codeSystem="2.16.840.1.113883.5.4"  
+         codeSystemName="ActCode"/>
+  <!-- Aggregate Count -->
+  <entryRelationship typeCode="SUBJ" inversionInd="true">
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+      <code code="MSRAGG" 
+        displayName="rate aggregation" 
+        codeSystem="2.16.840.1.113883.5.4" 
+        codeSystemName="ActCode"/>
+      <value xsi:type="INT" value="4"/>
+      <methodCode code="COUNT" 
+        displayName="Count" 
+        codeSystem="2.16.840.1.113883.5.84" 
+        codeSystemName="ObservationMethod"/>
+    </observation>
+  </entryRelationship>
+   
+   <!--    SEX Supplemental Data Reporting for IPP  0ABD1F84-09B1-421D-BE08-10F3B2413456      --> 
+         
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Sex Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="76689-9" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="F"
+             codeSystem="2.16.840.1.113883.5.1"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+   
+   <!--    SEX Supplemental Data Reporting for IPP  0ABD1F84-09B1-421D-BE08-10F3B2413456      --> 
+         
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Sex Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="76689-9" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="M"
+             codeSystem="2.16.840.1.113883.5.1"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="3"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+    <!--     ETHNICITY Supplemental Data Reporting  for IPP  0ABD1F84-09B1-421D-BE08-10F3B2413456     --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Ethnicity Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="69490-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2186-5"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="3"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+    <!--     ETHNICITY Supplemental Data Reporting  for IPP  0ABD1F84-09B1-421D-BE08-10F3B2413456     --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Ethnicity Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="69490-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2135-2"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+   <!--      RACE Supplemental Data Reporting  for IPP  0ABD1F84-09B1-421D-BE08-10F3B2413456 --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Race Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="72826-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="1002-5"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+   <!--      RACE Supplemental Data Reporting  for IPP  0ABD1F84-09B1-421D-BE08-10F3B2413456 --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Race Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="72826-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2028-9"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+   <!--      RACE Supplemental Data Reporting  for IPP  0ABD1F84-09B1-421D-BE08-10F3B2413456 --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Race Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="72826-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2054-5"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="1"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+ <!--         PAYER Supplemental Data Reporting   for IPP  0ABD1F84-09B1-421D-BE08-10F3B2413456   -->
+   <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Payer Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+        <id nullFlavor="NA" />
+      <code code="48768-6" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2"
+             codeSystem="2.16.840.1.113883.3.221.5"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+ <!--         PAYER Supplemental Data Reporting   for IPP  0ABD1F84-09B1-421D-BE08-10F3B2413456   -->
+   <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Payer Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+        <id nullFlavor="NA" />
+      <code code="48768-6" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="349"
+             codeSystem="2.16.840.1.113883.3.221.5"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="3"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+  <reference typeCode="REFR">
+     <externalObservation classCode="OBS" moodCode="EVN">
+        <id root="0ABD1F84-09B1-421D-BE08-10F3B2413456"/>
+     </externalObservation>
+  </reference>
+</observation>
+              </component>
+              <component>
+              
+<!--   MEASURE DATA REPORTING FOR    DENOM  B484793F-FF58-49CD-9F29-289B5246BF22  -->
+<observation classCode="OBS" moodCode="EVN">
+  <!-- Measure Data template -->
+  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+  <code code="ASSERTION" 
+        codeSystem="2.16.840.1.113883.5.4" 
+        displayName="Assertion" 
+        codeSystemName="ActCode"/>
+  <statusCode code="completed"/>
+  <value xsi:type="CD" code="DENOM"
+         codeSystem="2.16.840.1.113883.5.4"  
+         codeSystemName="ActCode"/>
+  <!-- Aggregate Count -->
+  <entryRelationship typeCode="SUBJ" inversionInd="true">
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+      <code code="MSRAGG" 
+        displayName="rate aggregation" 
+        codeSystem="2.16.840.1.113883.5.4" 
+        codeSystemName="ActCode"/>
+      <value xsi:type="INT" value="5"/>
+      <methodCode code="COUNT" 
+        displayName="Count" 
+        codeSystem="2.16.840.1.113883.5.84" 
+        codeSystemName="ObservationMethod"/>
+    </observation>
+  </entryRelationship>
+   
+   <!--    SEX Supplemental Data Reporting for DENOM  B484793F-FF58-49CD-9F29-289B5246BF22      --> 
+         
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Sex Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="76689-9" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="F"
+             codeSystem="2.16.840.1.113883.5.1"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+   
+   <!--    SEX Supplemental Data Reporting for DENOM  B484793F-FF58-49CD-9F29-289B5246BF22      --> 
+         
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Sex Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="76689-9" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="M"
+             codeSystem="2.16.840.1.113883.5.1"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="3"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+    <!--     ETHNICITY Supplemental Data Reporting  for DENOM  B484793F-FF58-49CD-9F29-289B5246BF22     --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Ethnicity Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="69490-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2186-5"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="3"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+    <!--     ETHNICITY Supplemental Data Reporting  for DENOM  B484793F-FF58-49CD-9F29-289B5246BF22     --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Ethnicity Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="69490-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2135-2"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+   <!--      RACE Supplemental Data Reporting  for DENOM  B484793F-FF58-49CD-9F29-289B5246BF22 --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Race Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="72826-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="1002-5"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+   <!--      RACE Supplemental Data Reporting  for DENOM  B484793F-FF58-49CD-9F29-289B5246BF22 --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Race Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="72826-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2028-9"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+   <!--      RACE Supplemental Data Reporting  for DENOM  B484793F-FF58-49CD-9F29-289B5246BF22 --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Race Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="72826-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2054-5"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="1"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+ <!--         PAYER Supplemental Data Reporting   for DENOM  B484793F-FF58-49CD-9F29-289B5246BF22   -->
+   <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Payer Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+        <id nullFlavor="NA" />
+      <code code="48768-6" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2"
+             codeSystem="2.16.840.1.113883.3.221.5"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+ <!--         PAYER Supplemental Data Reporting   for DENOM  B484793F-FF58-49CD-9F29-289B5246BF22   -->
+   <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Payer Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+        <id nullFlavor="NA" />
+      <code code="48768-6" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="349"
+             codeSystem="2.16.840.1.113883.3.221.5"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="3"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+  <reference typeCode="REFR">
+     <externalObservation classCode="OBS" moodCode="EVN">
+        <id root="B484793F-FF58-49CD-9F29-289B5246BF22"/>
+     </externalObservation>
+  </reference>
+</observation>
+              </component>
+              <component>
+              
+<!--   MEASURE DATA REPORTING FOR    NUMER  8E82739E-EE2A-4FA3-8593-01754A177BAB  -->
+<observation classCode="OBS" moodCode="EVN">
+  <!-- Measure Data template -->
+  <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+  <code code="ASSERTION" 
+        codeSystem="2.16.840.1.113883.5.4" 
+        displayName="Assertion" 
+        codeSystemName="ActCode"/>
+  <statusCode code="completed"/>
+  <value xsi:type="CD" code="NUMER"
+         codeSystem="2.16.840.1.113883.5.4"  
+         codeSystemName="ActCode"/>
+  <!-- Aggregate Count -->
+  <entryRelationship typeCode="SUBJ" inversionInd="true">
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+      <code code="MSRAGG" 
+        displayName="rate aggregation" 
+        codeSystem="2.16.840.1.113883.5.4" 
+        codeSystemName="ActCode"/>
+      <value xsi:type="INT" value="2"/>
+      <methodCode code="COUNT" 
+        displayName="Count" 
+        codeSystem="2.16.840.1.113883.5.84" 
+        codeSystemName="ObservationMethod"/>
+    </observation>
+  </entryRelationship>
+   
+   <!--    SEX Supplemental Data Reporting for NUMER  8E82739E-EE2A-4FA3-8593-01754A177BAB      --> 
+         
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Sex Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="76689-9" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="F"
+             codeSystem="2.16.840.1.113883.5.1"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="1"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+   
+   <!--    SEX Supplemental Data Reporting for NUMER  8E82739E-EE2A-4FA3-8593-01754A177BAB      --> 
+         
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Sex Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.6" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="76689-9" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="M"
+             codeSystem="2.16.840.1.113883.5.1"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="1"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+    <!--     ETHNICITY Supplemental Data Reporting  for NUMER  8E82739E-EE2A-4FA3-8593-01754A177BAB     --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Ethnicity Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="69490-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2186-5"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="1"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+    <!--     ETHNICITY Supplemental Data Reporting  for NUMER  8E82739E-EE2A-4FA3-8593-01754A177BAB     --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Ethnicity Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.7" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="69490-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2135-2"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="1"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+   <!--      RACE Supplemental Data Reporting  for NUMER  8E82739E-EE2A-4FA3-8593-01754A177BAB --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Race Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="72826-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="1002-5"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="1"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+   <!--      RACE Supplemental Data Reporting  for NUMER  8E82739E-EE2A-4FA3-8593-01754A177BAB --> 
+
+    <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Race Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.8" extension="2016-09-01"/>
+        <id nullFlavor="NA" />
+      <code code="72826-1" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="2028-9"
+             codeSystem="2.16.840.1.113883.6.238"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="1"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+
+ <!--         PAYER Supplemental Data Reporting   for NUMER  8E82739E-EE2A-4FA3-8593-01754A177BAB   -->
+   <!--                            Supplemental Data Template                                                  -->
+
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Payer Supplemental Data -->
+        <templateId root="2.16.840.1.113883.10.20.27.3.9" extension="2016-02-01"/>
+        <id nullFlavor="NA" />
+      <code code="48768-6" 
+            codeSystem="2.16.840.1.113883.6.1"/>
+      <statusCode code="completed"/>
+      
+      <value xsi:type="CD" 
+             code="349"
+             codeSystem="2.16.840.1.113883.3.221.5"/>
+      <entryRelationship typeCode="SUBJ" inversionInd="true">
+        <!-- Aggregate Count template -->
+        <observation classCode="OBS" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+          <code code="MSRAGG" 
+                displayName="rate aggregation" 
+                codeSystem="2.16.840.1.113883.5.4" 
+                codeSystemName="ActCode"/>
+          <value xsi:type="INT" value="2"/>
+          <methodCode code="COUNT" 
+                      displayName="Count" 
+                      codeSystem="2.16.840.1.113883.5.84" 
+                      codeSystemName="ObservationMethod"/>
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>    
+  <reference typeCode="REFR">
+     <externalObservation classCode="OBS" moodCode="EVN">
+        <id root="8E82739E-EE2A-4FA3-8593-01754A177BAB"/>
+     </externalObservation>
+  </reference>
+</observation>
+              </component>
+            </organizer>
+          </entry>
+          <entry>
+                      <act classCode="ACT" moodCode="EVN">
+              <!-- This is the templateId for Reporting Parameters Act -->
+              <templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+              <id extension="F79FD35B8E3CD0C5DE2DB8871D4A6BFE" />
+              <code code="252116004" codeSystem="2.16.840.1.113883.6.96" displayName="Observation Parameters"/>
+              <effectiveTime>
+                <low value="20170101000000"/>
+                <high value="20171231235959"/>
+              </effectiveTime>
+            </act>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/test/unit/qrda/cat3_test.rb
+++ b/test/unit/qrda/cat3_test.rb
@@ -1,0 +1,32 @@
+require_relative '../../test_helper'
+require 'cqm/models'
+require 'cqm_validators'
+
+module QRDA
+  module Cat3
+    class Cat3CVUTest < MiniTest::Test
+
+      def test_cat3_good
+        # Read in GOOD file in fixtures
+        doc = File.open("test/fixtures/cat3/qrda_cat_3_no_errors.xml") { |f| Nokogiri::XML(f) }
+        # Send file thru validator...
+        good_errors = CqmValidators::Cat3R21.instance.validate(doc, file_name: 'test')
+        # Shouldn't have any errors
+        assert_equal [], good_errors, 'Should be empty set of errors for a good schema'
+      end
+
+      def test_cat3_bad
+        # Read in BAD file in fixtures ("USA" is in there instead of "US")
+        doc = File.open("test/fixtures/cat3/qrda_cat_3_with_errors.xml") { |f| Nokogiri::XML(f) }
+        # Send file thru validator...
+        bad_errors = CqmValidators::Cat3R21.instance.validate(doc, file_name: 'test')
+        # Check if the error string below is in the array of errors (it should be)
+        error_string = "@code=\"US\" (CONF:3338-17227)."
+        bad_errors.any?{|err| err.message.include?(error_string)}
+        # If bad_errors is true (we had the expected errors we were looking for), this test should pass
+        assert bad_errors
+      end
+
+    end
+  end
+end

--- a/test/unit/qrda/cat3_test.rb
+++ b/test/unit/qrda/cat3_test.rb
@@ -4,7 +4,7 @@ require 'cqm_validators'
 
 module QRDA
   module Cat3
-    class Cat3CVUTest < MiniTest::Test
+    class Cat3ValidationTest < MiniTest::Test
 
       def test_cat3_good
         # Read in GOOD file in fixtures


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

There was a failure caused by a schematron issue that had been addressed, but added tests were required to ensure this does not occur again. This PR addresses Cat3 schematron validation testing.

**Submitter:**
- [X] This pull request describes why these changes were made.
- [X] Internal ticket for this PR: [CYPRESS-368](https://jira.mitre.org/browse/CYPRESS-368)
- [X] Internal ticket links to this PR: [ONC Tracking 1540](https://oncprojectracking.healthit.gov/support/browse/CYPRESS-1540)
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code