### PR TITLE
Support QDM::ProviderCharacteristic

### DIFF
--- a/lib/cqm_report.rb
+++ b/lib/cqm_report.rb
@@ -53,6 +53,7 @@ require_relative 'qrda-import/data-element-importers/medication_discharge_import
 require_relative 'qrda-import/data-element-importers/medication_dispensed_importer.rb'
 require_relative 'qrda-import/data-element-importers/patient_characteristic_expired.rb'
 require_relative 'qrda-import/data-element-importers/procedure_order_importer.rb'
+require_relative 'qrda-import/data-element-importers/provider_characteristic_importer.rb'
 require_relative 'qrda-import/data-element-importers/substance_administered_importer.rb'
 require_relative 'qrda-import/data-element-importers/symptom_importer.rb'
 require_relative 'qrda-import/patient_importer.rb'

--- a/lib/qrda-export/catI-r5/qrda1_r5.mustache
+++ b/lib/qrda-export/catI-r5/qrda1_r5.mustache
@@ -122,6 +122,10 @@
             {{> qrda_templates/procedure_performed}}
           {{/procedure_performed}}
 
+          {{#provider_characteristic}}
+            {{> qrda_templates/provider_characteristic}}
+          {{/provider_characteristic}}
+
           {{#symptom}}
             {{> qrda_templates/symptom}}
           {{/symptom}}

--- a/lib/qrda-export/catI-r5/qrda1_r5.rb
+++ b/lib/qrda-export/catI-r5/qrda1_r5.rb
@@ -122,6 +122,10 @@ class Qrda1R5 < Mustache
     JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('procedure', 'performed') }).to_json)
   end
 
+  def provider_characteristic
+    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('provider_characteristic', '') }).to_json)
+  end
+
   def symptom
     JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('symptom', '') }).to_json)
   end

--- a/lib/qrda-export/catI-r5/qrda_templates/provider_characteristic.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/provider_characteristic.mustache
@@ -1,0 +1,15 @@
+<entry>
+  <observation classCode="OBS" moodCode="EVN">
+    <!-- Provider Characteristic Observation Assertion (V3) -->
+    <templateId root="2.16.840.1.113883.10.20.24.3.114" extension="2017-08-01"/>
+    <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
+    <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="HL7ActCode" />
+    <statusCode code="completed" />
+    <!-- Provider Characteristic -->
+    {{> qrda_templates/template_partials/_data_element_codes_as_values}}
+    {{#authorDatetime}}
+      <!-- QDM Attribute: Author dateTime -->
+      {{> qrda_templates/template_partials/_author}}
+    {{/authorDatetime}}
+  </observation>
+</entry>

--- a/lib/qrda-import/data-element-importers/provider_characteristic_importer.rb
+++ b/lib/qrda-import/data-element-importers/provider_characteristic_importer.rb
@@ -1,0 +1,19 @@
+module QRDA
+  module Cat1
+    class ProviderCharacteristicImporter < SectionImporter
+      def initialize(entry_finder = QRDA::Cat1::EntryFinder.new("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.114']"))
+        super(entry_finder)
+        @id_xpath = './cda:id'
+        @code_xpath = "./cda:value"
+        @author_datetime_xpath = "./cda:author/cda:time"
+        @entry_class = QDM::ProviderCharacteristic
+      end
+
+      def create_entry(entry_element, nrh = NarrativeReferenceHandler.new)
+        provider_characteristic = super
+        provider_characteristic
+      end
+
+    end
+  end
+end

--- a/lib/qrda-import/patient_importer.rb
+++ b/lib/qrda-import/patient_importer.rb
@@ -40,6 +40,7 @@ module QRDA
         @data_element_importers << generate_importer(MedicationDispensedImporter)
         @data_element_importers << generate_importer(PatientCharacteristicExpired)
         @data_element_importers << generate_importer(ProcedureOrderImporter)
+        @data_element_importers << generate_importer(ProviderCharacteristicImporter)
         @data_element_importers << generate_importer(SubstanceAdministeredImporter)
         @data_element_importers << generate_importer(SymptomImporter)
 


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
