### PR TITLE
Clean up comm

### DIFF
--- a/lib/qrda-export/catI-r5/qrda_templates/communication_performed.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/communication_performed.mustache
@@ -3,15 +3,26 @@
         <templateId root="2.16.840.1.113883.10.20.24.3.156" extension="2018-10-01"/>
         <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
         {{#category}}
-        <code {{> _code}}/>
+          <!-- QDM Attribute: Category -->
+          <code {{> _code}}/>
         {{/category}}
         <statusCode code="completed"/>
         {{#relevantPeriod}}
-        {{{relevant_period}}}
+          <!-- QDM Attribute: Relevant Period -->
+          {{{relevant_period}}}
         {{/relevantPeriod}}
         {{#authorDatetime}}
-        {{> qrda_templates/template_partials/_author}}
+          <!-- QDM Attribute: Author dateTime -->
+          {{> qrda_templates/template_partials/_author}}
         {{/authorDatetime}}
+        {{#recipient}}
+        <participant typeCode="IRCP">
+            <participantRole>
+                <!-- QDM Attribute: Recipient -->
+                <code code="158965000" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Medical Practitioner"/>
+            </participantRole>
+        </participant>
+        {{/recipient}}
         {{#sender}}
         <participant typeCode="AUT">
             <participantRole>
@@ -19,34 +30,33 @@
             </participantRole>
         </participant>
         {{/sender}}
-        {{#recipient}}
-        <participant typeCode="IRCP">
-            <participantRole>
-                <code code="158965000" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Medical Practitioner"/>
-            </participantRole>
-        </participant>
-        {{/recipient}}
         {{#medium}}
         <participant typeCode="VIA">
             <participantRole>
+                <!-- QDM Attribute: Medium -->
                 <code {{> _code}}/>
             </participantRole>
         </participant>
         {{/medium}}
+        {{#negationRationale}}
+          <!-- QDM Attribute: Negation Rationale -->
+          {{> qrda_templates/template_partials/_reason}}
+        {{/negationRationale}}
+        {{^negationRationale}}
         <entryRelationship typeCode="RSON">
           <observation classCode="OBS" moodCode="EVN">
             <templateId root="2.16.840.1.113883.10.20.24.3.88" extension="2014-12-01"/>
             <id root="1.3.6.1.4.1.115" extension="{{object_id}}" />
             <code code="77301-0" codeSystem="2.16.840.1.113883.6.1" displayName="reason" codeSystemName="LOINC"/>
             <statusCode code="completed"/>
+            <!-- QDM Attribute: Code -->
             {{> qrda_templates/template_partials/_data_element_codes_as_values}}
           </observation>
         </entryRelationship>
-        {{#negationRationale}}
-        {{> qrda_templates/template_partials/_reason}}
         {{/negationRationale}}
         {{#relatedTo}}
-        {{> qrda_templates/template_partials/_related_to}}
+          <!-- QDM Attribute: relatedTo -->
+          {{> qrda_templates/template_partials/_related_to}}
         {{/relatedTo}}
     </act>
 </entry>

--- a/lib/qrda-import/data-element-importers/communication_performed_importer.rb
+++ b/lib/qrda-import/data-element-importers/communication_performed_importer.rb
@@ -23,10 +23,6 @@ module QRDA
           communication_performed.sender = code_if_present(entry_element.at_xpath(@sender_xpath))
           communication_performed.recipient = code_if_present(entry_element.at_xpath(@recipient_xpath))
           communication_performed.relatedTo = extract_related_to(entry_element)
-          communication_performed.category = code_if_present(entry_element.at_xpath(@category_xpath))
-          communication_performed.medium = code_if_present(entry_element.at_xpath(@medium_xpath))
-          communication_performed.sender = code_if_present(entry_element.at_xpath(@sender_xpath))
-          communication_performed.recipient = code_if_present(entry_element.at_xpath(@recipient_xpath))
           communication_performed
         end
       end


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
