### PR TITLE
Small changes as a result of running against the QRDA Cat I 5_1 schem…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,6 @@ group :test do
   gem 'minitest', '~> 5.3'
   gem 'minitest-reporters'
   gem 'awesome_print', :require => 'ap'
-  gem 'cqm-validators'
+  gem 'cqm-validators', git: 'https://github.com/projecttacoma/cqm-validators.git', branch: 'qrda_5_1'
   gem 'nokogiri-diff'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,14 @@ GIT
   specs:
     cqm-models (1.0.2)
 
+GIT
+  remote: https://github.com/projecttacoma/cqm-validators.git
+  revision: 3d601b056203c75b531585675590b152bc7a9a2e
+  branch: qrda_5_1
+  specs:
+    cqm-validators (0.1.0)
+      nokogiri (~> 1.8.2)
+
 PATH
   remote: .
   specs:
@@ -46,8 +54,6 @@ GEM
       simplecov
       url
     concurrent-ruby (1.1.4)
-    cqm-validators (0.1.0)
-      nokogiri (~> 1.8.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     docile (1.3.1)
@@ -144,7 +150,7 @@ DEPENDENCIES
   codecov
   cqm-models!
   cqm-reports!
-  cqm-validators
+  cqm-validators!
   factory_girl (~> 4.1.0)
   minitest (~> 5.3)
   minitest-reporters
@@ -159,4 +165,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.3
+   1.17.3

--- a/lib/qrda-export/catI-r5/qrda_templates/communication_performed.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/communication_performed.mustache
@@ -22,7 +22,7 @@
         {{#recipient}}
         <participant typeCode="IRCP">
             <participantRole>
-                <code {{> _code}}/>
+                <code code="158965000" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Medical Practitioner"/>
             </participantRole>
         </participant>
         {{/recipient}}

--- a/lib/qrda-export/catI-r5/qrda_templates/medication_order.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/medication_order.mustache
@@ -11,6 +11,12 @@
       <!-- QDM Attribute: Relevant Period -->
       {{{medication_duration_effective_time}}}
     {{/relevantPeriod}}
+    {{^relevantPeriod}}
+      {{#authorDatetime}}
+        <!-- QDM Attribute: Relevant Period -->
+        {{{medication_duration_author_effective_time}}}
+      {{/authorDatetime}}
+    {{/relevantPeriod}}
     {{> qrda_templates/template_partials/_medication_details}}
     <consumable>
       <manufacturedProduct classCode="MANU">

--- a/lib/qrda-export/helper/date_helper.rb
+++ b/lib/qrda-export/helper/date_helper.rb
@@ -58,6 +58,13 @@ module Qrda
           "</effectiveTime>"
         end
 
+        def medication_duration_author_effective_time
+          "<effectiveTime xsi:type='IVL_TS'>"\
+          "<low #{value_or_null_flavor(self['authorDatetime'])}/>"\
+          "<high nullFlavor='UNK'/>"\
+          "</effectiveTime>"
+        end
+
         def prevalence_period
           "<effectiveTime>"\
           "<low #{value_or_null_flavor(self['prevalencePeriod']['low'])}/>"\

--- a/test/unit/qrda/patient_round_trip_test.rb
+++ b/test/unit/qrda/patient_round_trip_test.rb
@@ -93,7 +93,7 @@ module QRDA
       def test_exhaustive_qrda_validation
         puts "\n========================= QRDA VALIDATION ========================="
         cqm_patients = QDM::PatientGeneration.generate_exhastive_data_element_patients(true)
-        validator = CqmValidators::Cat1R5.instance
+        validator = CqmValidators::Cat1R51.instance
         cda_validator = CqmValidators::CDA.instance
         successful_count = 0
         cqm_patients.each do |cqm_patient|


### PR DESCRIPTION
…atron

Two Changes.
"Medication Order" template always needs a 'Relevant Period'.  However, this template is also used by "Substance Order" which does not have a 'Relevant Period'.  As a result, use the QRDA guidance to use the authorDate time.

<img width="645" alt="image" src="https://user-images.githubusercontent.com/8173551/54454870-d8094800-4730-11e9-8d49-2814226bb8b4.png">

"Communication"
The Information Recipient is always a fixed code '158965000'

<img width="626" alt="image" src="https://user-images.githubusercontent.com/8173551/54454984-16066c00-4731-11e9-88e9-829c2c4b5b84.png">



Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code