### PR TITLE
update to use get_data_elements where appropriate. patient_care_exper…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,9 @@ source 'https://rubygems.org'
 gemspec :development_group => :test
 
 gem 'mongoid', '~> 6.4.2'
-gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models.git', branch: 'provider'
+
+gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models.git', branch: 'master'
+
 gem 'protected_attributes_continued'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/projecttacoma/cqm-models.git
-  revision: 590e21cbdc5a33b8e35edc5f29db2becc74d11b6
-  branch: provider
+  revision: b2be2d00f83a2d49e2d3332fc6c454d80d41a6eb
+  branch: master
   specs:
     cqm-models (1.0.2)
 

--- a/lib/qrda-export/catI-r5/qrda1_r5.rb
+++ b/lib/qrda-export/catI-r5/qrda1_r5.rb
@@ -20,139 +20,139 @@ class Qrda1R5 < Mustache
   end
 
   def patient_characteristic_birthdate
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: '2.16.840.1.113883.10.20.28.3.54').to_json)
+    JSON.parse(@qdmPatient.get_data_elements('patient_characteristic', 'birthdate').to_json)
   end
 
   def patient_characteristic_sex
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: '2.16.840.1.113883.10.20.28.3.55').to_json)
+    JSON.parse(@qdmPatient.get_data_elements('patient_characteristic', 'gender').to_json)
   end
 
   def patient_characteristic_race
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: '2.16.840.1.113883.10.20.28.3.59').to_json)
+    JSON.parse(@qdmPatient.get_data_elements('patient_characteristic', 'race').to_json)
   end
 
   def patient_characteristic_ethnicity
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: '2.16.840.1.113883.10.20.28.3.56').to_json)
+    JSON.parse(@qdmPatient.get_data_elements('patient_characteristic', 'ethnicity').to_json)
   end
 
   def adverse_event
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('adverse_event', '') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('adverse_event', nil).to_json)
   end
 
   def allergy_intolerance
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('allergy_intolerance', '') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('allergy', 'intolerance').to_json)
   end
 
   def assessment_order
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('assessment', 'ordered') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('assessment', 'order').to_json)
   end
 
   def assessment_performed
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('assessment', 'performed') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('assessment', 'performed').to_json)
   end
 
   def assessment_recommended
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('assessment', 'recommended') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('assessment', 'recommended').to_json)
   end
 
   def communication_performed
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('communication', 'performed') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('communication', 'performed').to_json)
   end
 
   def diagnosis
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('diagnosis', '') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('condition', nil).to_json)
   end
 
   def device_applied
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('device', 'applied') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('device', 'applied').to_json)
   end
 
   def device_order
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('device', 'ordered') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('device', 'order').to_json)
   end
 
   def device_recommended
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('device', 'recommended') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('device', 'recommended').to_json)
   end
 
   def diagnostic_study_order
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('diagnostic_study', 'ordered') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('diagnostic_study', 'order').to_json)
   end
 
   def diagnostic_study_performed
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('diagnostic_study', 'performed') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('diagnostic_study', 'performed').to_json)
   end
 
   def diagnostic_study_recommended
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('diagnostic_study', 'recommended') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('diagnostic_study', 'recommended').to_json)
   end
 
   def encounter_order
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('encounter', 'ordered') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('encounter', 'order').to_json)
   end
 
   def encounter_performed
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('encounter', 'performed') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('encounter', 'performed').to_json)
   end
 
   def encounter_recommended
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('encounter', 'recommended') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('encounter', 'recommended').to_json)
   end
 
   def family_history
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('family_history', '') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('family_history', nil).to_json)
   end
 
   def immunization_administered
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('immunization', 'administered') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('immunization', 'administered').to_json)
   end
 
   def immunization_order
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('immunization', 'order') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('immunization', 'order').to_json)
   end
 
   def intervention_order
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('intervention', 'ordered') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('intervention', 'order').to_json)
   end
 
   def intervention_performed
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('intervention', 'performed') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('intervention', 'performed').to_json)
   end
 
   def intervention_recommended
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('intervention', 'recommended') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('intervention', 'recommended').to_json)
   end
 
   def laboratory_test_order
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('laboratory_test', 'ordered') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('laboratory_test', 'order').to_json)
   end
 
   def laboratory_test_performed
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('laboratory_test', 'performed') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('laboratory_test', 'performed').to_json)
   end
 
   def laboratory_test_recommended
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('laboratory_test', 'recommended') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('laboratory_test', 'recommended').to_json)
   end
 
   def medication_active
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('medication', 'active') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('medication', 'active').to_json)
   end
 
   def medication_administered
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('medication', 'administered') + HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('substance', 'administered') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('medication', 'administered').to_json) + JSON.parse(@qdmPatient.get_data_elements('substance', 'administered').to_json)
   end
 
   def medication_discharge
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('medication', 'discharge') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('medication', 'discharge').to_json)
   end
 
   def medication_dispensed
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('medication', 'dispensed') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('medication', 'dispensed').to_json)
   end
 
   def medication_order
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('medication', 'ordered') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('medication', 'order').to_json)
   end
 
   def patient_care_experience
@@ -160,35 +160,35 @@ class Qrda1R5 < Mustache
   end
 
   def patient_characteristic_clinical_trial_participant
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('patient_characteristic', 'clinical_trial_participant') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('patient_characteristic', 'clinical_trial_participant').to_json)
   end
 
   def patient_characteristic_expired
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('patient_characteristic_expired', '') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('patient_characteristic', 'expired').to_json)
   end
 
   def physical_exam_order
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('physical_exam', 'ordered') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('physical_exam', 'order').to_json)
   end
   
   def physical_exam_performed
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('physical_exam', 'performed') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('physical_exam', 'performed').to_json)
   end
 
   def physical_exam_recommended
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('physical_exam', 'recommended') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('physical_exam', 'recommended').to_json)
   end
 
   def procedure_order
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('procedure', 'ordered') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('procedure', 'order').to_json)
   end
 
   def procedure_performed
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('procedure', 'performed') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('procedure', 'performed').to_json)
   end
 
   def procedure_recommended
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('procedure', 'recommended') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('procedure', 'recommended').to_json)
   end
 
   def provider_care_experience
@@ -196,22 +196,22 @@ class Qrda1R5 < Mustache
   end
 
   def provider_characteristic
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('provider_characteristic', '') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('provider_characteristic', nil).to_json)
   end
 
   def substance_administered
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('substance', 'administered') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('substance', 'administered').to_json)
   end
 
   def substance_order
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('substance', 'ordered') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('substance', 'order').to_json)
   end
 
   def substance_recommended
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('substance', 'recommended') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('substance', 'recommended').to_json)
   end
   
   def symptom
-    JSON.parse(@qdmPatient.dataElements.where(hqmfOid: { '$in' => HQMF::Util::HQMFTemplateHelper.get_all_hqmf_oids('symptom', '') }).to_json)
+    JSON.parse(@qdmPatient.get_data_elements('symptom', nil).to_json)
   end
 end


### PR DESCRIPTION
…ience and provider_care_experience left as is.

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] Code diff has been done and been reviewed
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: @mayerm94 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
