### PR TITLE
Remove byebug require

### DIFF
--- a/lib/qrda-export/helper/cat1_view_helper.rb
+++ b/lib/qrda-export/helper/cat1_view_helper.rb
@@ -1,4 +1,3 @@
-require 'byebug'
 module Qrda
   module Export
     module Helper


### PR DESCRIPTION
Remove a stray `require 'byebug'` that made its way into a file. Since `byebug` is only in the `Gemfile` for dev/test groups, this caused issues when trying to use `cqm-reports` in a production environment.

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links to this PR N/A
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: @mayerm94
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
