### PR TITLE
Result attributes are still printed with (urn:hl7ii:2.16.840.1.113883…

### DIFF
--- a/lib/qrda-export/catI-r5/qrda_templates/template_partials/_results.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/template_partials/_results.mustache
@@ -2,8 +2,6 @@
  <observation classCode="OBS" moodCode="EVN">
     <!-- Conforms to C-CDA R2 Result Observation (V2) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.2" extension="2015-08-01"/>
-    <!-- Result (QRDA I R3) -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.87" extension="2016-02-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{random_id}}"/>
     {{> _codes}}
     <statusCode code="completed"/>

--- a/lib/qrda-import/data-element-importers/diagnostic_study_performed_importer.rb
+++ b/lib/qrda-import/data-element-importers/diagnostic_study_performed_importer.rb
@@ -7,8 +7,8 @@ module QRDA
         @code_xpath = './cda:code'
         @relevant_period_xpath = "./cda:effectiveTime"
         @author_datetime_xpath = "./cda:author/cda:time"
-        @result_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.87']/cda:value"
-        @result_datetime_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.87']/cda:effectiveTime"
+        @result_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.22.4.2']/cda:value"
+        @result_datetime_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.22.4.2']/cda:effectiveTime"
         @status_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.93']/cda:value"
         @method_xpath = './cda:methodCode'
         @facility_locations_xpath = "./cda:participant[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.100']"

--- a/lib/qrda-import/data-element-importers/intervention_performed_importer.rb
+++ b/lib/qrda-import/data-element-importers/intervention_performed_importer.rb
@@ -7,7 +7,7 @@ module QRDA
         @code_xpath = './cda:code'
         @relevant_period_xpath = "./cda:effectiveTime"
         @author_datetime_xpath = "./cda:author/cda:time"
-        @result_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.87']/cda:value"
+        @result_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.22.4.2']/cda:value"
         @status_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.93']/cda:value"
         @entry_class = QDM::InterventionPerformed
       end

--- a/lib/qrda-import/data-element-importers/laboratory_test_performed_importer.rb
+++ b/lib/qrda-import/data-element-importers/laboratory_test_performed_importer.rb
@@ -9,7 +9,7 @@ module QRDA
         @author_datetime_xpath = "./cda:author/cda:time"
         @status_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.93']/cda:value"
         @method_xpath = './cda:methodCode'
-        @result_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.87']/cda:value"
+        @result_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.22.4.2']/cda:value"
         @result_datetime_xpath = "./cda:entryRelationship[@typeCode='REFR']/cda:observation/cda:effectiveTime"
         @components_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.149']"
         @entry_class = QDM::LaboratoryTestPerformed

--- a/lib/qrda-import/data-element-importers/procedure_performed_importer.rb
+++ b/lib/qrda-import/data-element-importers/procedure_performed_importer.rb
@@ -8,7 +8,7 @@ module QRDA
         @relevant_period_xpath = "./cda:effectiveTime"
         @author_datetime_xpath = "./cda:author/cda:time"
         @method_xpath = './cda:methodCode'
-        @result_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.87']/cda:value"
+        @result_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.22.4.2']/cda:value"
         @status_xpath = "./cda:entryRelationship/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.93']/cda:value"
         @anatomical_location_site_xpath = "./cda:targetSiteCode"
         @ordinality_xpath = "./cda:priorityCode"


### PR DESCRIPTION
….10.20.24.3.87) this was also used for import

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] External ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/CYPRESS-1634
- [ ] Internal ticket links to this PR 
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code