### PR TITLE
When a code uses the code system 'NA_VALUESET', negate an entire valu…

### DIFF
--- a/lib/qrda-export/helper/cat1_view_helper.rb
+++ b/lib/qrda-export/helper/cat1_view_helper.rb
@@ -33,9 +33,9 @@ module Qrda
 
         def code_and_codesystem
           if self['codeSystem'] == 'NA_VALUESET'
-            return "nullFlavor=\"NA\" sdtc:valueSet=\"#{self['code']}\""
+            "nullFlavor=\"NA\" sdtc:valueSet=\"#{self['code']}\""
           else
-            return "code=\"#{self['code']}\" codeSystem=\"#{code_system_oid(self)}\" codeSystemName=\"#{self['codeSystem']}\""
+            "code=\"#{self['code']}\" codeSystem=\"#{code_system_oid(self)}\" codeSystemName=\"#{self['codeSystem']}\""
           end
         end
 

--- a/lib/qrda-export/helper/cat1_view_helper.rb
+++ b/lib/qrda-export/helper/cat1_view_helper.rb
@@ -32,7 +32,11 @@ module Qrda
         end
 
         def code_and_codesystem
-          "code=\"#{self['code']}\" codeSystem=\"#{code_system_oid(self)}\" codeSystemName=\"#{self['codeSystem']}\""
+          if self['codeSystem'] == 'NA_VALUESET'
+            return "nullFlavor=\"NA\" sdtc:valueSet=\"#{self['code']}\""
+          else
+            return "code=\"#{self['code']}\" codeSystem=\"#{code_system_oid(self)}\" codeSystemName=\"#{self['codeSystem']}\""
+          end
         end
 
         def primary_code_and_codesystem

--- a/test/unit/qrda/patient_round_trip_test.rb
+++ b/test/unit/qrda/patient_round_trip_test.rb
@@ -113,7 +113,7 @@ module QRDA
         cqm_patient.qdmPatient = qdm_patient
         options = { start_time: Date.new(2012, 1, 1), end_time: Date.new(2012, 12, 31) }
         doc = generate_doc(cqm_patient, options)
-        assert_equal 1 , doc.xpath('//cda:code[@nullFlavor="NA" and @sdtc:valueSet="1.2.3.4"]').size
+        assert_equal 1, doc.xpath('//cda:code[@nullFlavor="NA" and @sdtc:valueSet="1.2.3.4"]').size
       end
 
       def test_provider_roundtrip

--- a/test/unit/qrda/patient_round_trip_test.rb
+++ b/test/unit/qrda/patient_round_trip_test.rb
@@ -104,6 +104,18 @@ module QRDA
         provider
       end
 
+      def test_negated_vs
+        cqm_patient = generate_shell_patient('negated_vs')
+        qdm_patient = QDM::Patient.new
+        dt = QDM::PatientGeneration.generate_loaded_datatype('QDM::EncounterOrder', true)
+        dt.dataElementCodes = [QDM::Code.new('1.2.3.4', 'NA_VALUESET')]
+        qdm_patient.dataElements << dt
+        cqm_patient.qdmPatient = qdm_patient
+        options = { start_time: Date.new(2012, 1, 1), end_time: Date.new(2012, 12, 31) }
+        doc = generate_doc(cqm_patient, options)
+        assert_equal 1 , doc.xpath('//cda:code[@nullFlavor="NA" and @sdtc:valueSet="1.2.3.4"]').size
+      end
+
       def test_provider_roundtrip
         cqm_patient = generate_shell_patient('provider')
         provider = generate_provider


### PR DESCRIPTION
…eset

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name: @mayerm94 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
