### PR TITLE
only export a provider id if the value/namesystem is provided

### DIFF
--- a/lib/qrda-export/catI-r5/qrda_templates/medication_dispensed.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/medication_dispensed.mustache
@@ -35,7 +35,7 @@
         <participant typeCode="PRF">
           <participantRole>
             <!-- QDM Attribute: Prescriber Id -->
-            <id root="{{namingSystem}}" extension="{{value}}"/>
+            {{{id_or_null_flavor}}}
           </participantRole>
         </participant>
         {{/prescriberId}}

--- a/lib/qrda-export/catI-r5/qrda_templates/template_partials/_author.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/template_partials/_author.mustache
@@ -6,7 +6,7 @@
   <assignedAuthor>
     {{#display_author_dispenser_id?}}
       {{#dispenserId}}
-        <id root="{{namingSystem}}" extension="{{value}}"/>
+        {{{id_or_null_flavor}}}
       {{/dispenserId}}
       {{^dispenserId}}
         <id nullFlavor="NA"/>
@@ -15,7 +15,7 @@
     {{^display_author_dispenser_id?}}
       {{#display_author_prescriber_id?}}
         {{#prescriberId}}
-          <id root="{{namingSystem}}" extension="{{value}}"/>
+          {{{id_or_null_flavor}}}
         {{/prescriberId}}
         {{^prescriberId}}
           <id nullFlavor="NA"/>

--- a/lib/qrda-export/helper/cat1_view_helper.rb
+++ b/lib/qrda-export/helper/cat1_view_helper.rb
@@ -22,6 +22,11 @@ module Qrda
           self['qdmCategory'] == 'medication' && self['qdmStatus'] == 'order'
         end
 
+        def id_or_null_flavor
+          return "<id root=\"#{self['namingSystem']}\" extension=\"#{self['value']}\"/>" if self['namingSystem'] && self['value']
+          return "<id nullFlavor=\"NA\"/>"
+        end
+
         def code_system_oid(data_element_code)
           data_element_code['codeSystemOid'] || HQMF::Util::CodeSystemHelper.oid_for_code_system(data_element_code['codeSystem'])
         end

--- a/lib/qrda-export/helper/cat1_view_helper.rb
+++ b/lib/qrda-export/helper/cat1_view_helper.rb
@@ -24,7 +24,7 @@ module Qrda
 
         def id_or_null_flavor
           return "<id root=\"#{self['namingSystem']}\" extension=\"#{self['value']}\"/>" if self['namingSystem'] && self['value']
-          return "<id nullFlavor=\"NA\"/>"
+          "<id nullFlavor=\"NA\"/>"
         end
 
         def code_system_oid(data_element_code)


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
