### PR TITLE
use value and naming system when finding unique QRDA entries

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,10 @@ Metrics/AbcSize:
     - 'lib/qrda-import/patient_importer.rb'
 
 Metrics/ClassLength:
+  Max: 110
   Exclude:
+    - 'lib/qrda-import/base-importers/section_importer.rb'
+    - 'lib/qrda-export/catI-r5/qrda1_r5.rb'
     - 'test/**/*'
 
 Metrics/MethodLength:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -143,11 +143,6 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Max: 35
 
-# Offense count: 4
-# Configuration parameters: CountComments.
-Metrics/ClassLength:
-  Max: 184
-
 # Offense count: 5
 Metrics/CyclomaticComplexity:
   Max: 15

--- a/lib/qrda-import/base-importers/section_importer.rb
+++ b/lib/qrda-import/base-importers/section_importer.rb
@@ -38,8 +38,12 @@ module QRDA
 
       def create_entry(entry_element, _nrh = NarrativeReferenceHandler.new)
         entry = @entry_class.new
-        @entry_id_map[extract_id(entry_element, @id_xpath).value] ||= []
-        @entry_id_map[extract_id(entry_element, @id_xpath).value] << entry.id
+        # This is the id found in the QRDA file
+        entry_qrda_id = extract_id(entry_element, @id_xpath)
+        # Create a hash to map all of entry.ids to the same QRDA ids. This will be used to merge QRDA entries
+        # that represent the same event. 
+        @entry_id_map["#{entry_qrda_id.value}_#{entry_qrda_id.namingSystem}"] ||= []
+        @entry_id_map["#{entry_qrda_id.value}_#{entry_qrda_id.namingSystem}"] << entry.id
         entry.dataElementCodes = extract_codes(entry_element, @code_xpath)
         extract_dates(entry_element, entry)
         if @result_xpath


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
