### PR TITLE
Use cqm-models in gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec :development_group => :test
 
 gem 'mongoid', '~> 6.4.2'
 
-gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models.git', branch: 'master'
+# gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models.git', branch: 'master'
 
 gem 'protected_attributes_continued'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,4 @@
 GIT
-  remote: https://github.com/projecttacoma/cqm-models.git
-  revision: 1538fb1dce6b63c2fbec5e27f639389f92604242
-  branch: master
-  specs:
-    cqm-models (1.0.2)
-
-GIT
   remote: https://github.com/projecttacoma/cqm-validators.git
   revision: 119a54a428dc613dfa56986f64f0a30d8bc56291
   branch: master
@@ -17,6 +10,7 @@ PATH
   remote: .
   specs:
     cqm-reports (1.0.0.0)
+      cqm-models (~> 1.1.1.0)
       erubis (~> 2.7.0)
       log4r (~> 1.1.10)
       memoist (~> 0.9.1)
@@ -54,6 +48,7 @@ GEM
       simplecov
       url
     concurrent-ruby (1.1.4)
+    cqm-models (1.1.1.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     docile (1.3.1)
@@ -147,7 +142,6 @@ DEPENDENCIES
   byebug
   cane (~> 2.3.0)
   codecov
-  cqm-models!
   cqm-reports!
   cqm-validators!
   factory_girl (~> 4.1.0)

--- a/cqm-reports.gemspec
+++ b/cqm-reports.gemspec
@@ -9,6 +9,8 @@ Gem::Specification.new do |s|
 
   s.version = '1.0.0.0'
 
+  s.add_dependency 'cqm-models', '~> 1.1.1.0'
+
   s.add_dependency 'mustache'
 
   s.add_dependency 'erubis', '~> 2.7.0'


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
