### PR TITLE
Add support for exporting CMS templates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,8 +10,9 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Max: 110
   Exclude:
-    - 'lib/qrda-import/base-importers/section_importer.rb'
+    - 'lib/qrda-import/base-importers/section_importer.rb'    
     - 'lib/qrda-export/catI-r5/qrda1_r5.rb'
+    - 'lib/qrda-export/catIII-r2-1/qrda3_r21.rb'
     - 'test/**/*'
 
 Metrics/MethodLength:

--- a/lib/qrda-export/catIII-r2-1/_header.mustache
+++ b/lib/qrda-export/catIII-r2-1/_header.mustache
@@ -3,6 +3,8 @@
 <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 <!-- US Realm Header Template Id -->
 <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
+<!-- QRDA Category III Report - CMS (V4) -->
+<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2019-05-01"/>
 <!-- This is the globally unique identifier for this QRDA document -->
 <id root="{{random_id}}"/>
 <!-- QRDA III document type code -->
@@ -21,5 +23,10 @@
 </recordTarget>
 {{> qrda_header/_author}}
 {{> qrda_header/_custodian}}
+{{> qrda_header/_information_recipient}}
 {{> qrda_header/_legal_authenticator}}
+{{#is_cpcplus?}}
+  {{> qrda_header/_participant_location}}
+{{/is_cpcplus?}}
+{{> qrda_header/_participant_ehr}}
 {{> qrda_header/_documentation_of_service_event}}

--- a/lib/qrda-export/catIII-r2-1/_header.mustache
+++ b/lib/qrda-export/catIII-r2-1/_header.mustache
@@ -25,8 +25,8 @@
 {{> qrda_header/_custodian}}
 {{> qrda_header/_information_recipient}}
 {{> qrda_header/_legal_authenticator}}
-{{#is_cpcplus?}}
+{{#cpcplus?}}
   {{> qrda_header/_participant_location}}
-{{/is_cpcplus?}}
+{{/cpcplus?}}
 {{> qrda_header/_participant_ehr}}
 {{> qrda_header/_documentation_of_service_event}}

--- a/lib/qrda-export/catIII-r2-1/_measure_data.mustache
+++ b/lib/qrda-export/catIII-r2-1/_measure_data.mustache
@@ -5,6 +5,8 @@
   <observation classCode="OBS" moodCode="EVN">
     <!-- Measure Data template -->
     <templateId root="2.16.840.1.113883.10.20.27.3.5" extension="2016-09-01"/>
+    <!-- Measure Data - CMS (V4) -->
+    <templateId root="2.16.840.1.113883.10.20.27.3.16" extension="2019-05-01"/>
     <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" displayName="Assertion" codeSystemName="ActCode"/>
     <statusCode code="completed"/>
     <value xsi:type="CD" code="{{population_type}}" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>

--- a/lib/qrda-export/catIII-r2-1/_measure_section.mustache
+++ b/lib/qrda-export/catIII-r2-1/_measure_section.mustache
@@ -10,6 +10,8 @@
     <!-- In this case the query is using an eMeasure -->
     <!-- QRDA Category III Measure Section template -->
     <templateId extension="2017-06-01" root="2.16.840.1.113883.10.20.27.2.1"/>
+    <!-- QRDA Category III Measure Section - CMS (V4) -->
+    <templateId extension="2019-05-01" root="2.16.840.1.113883.10.20.27.2.3"/>
     <code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
     <title>Measure Section</title>
     <text>
@@ -39,6 +41,7 @@
         <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
         <!-- SHALL 1..* (one for each referenced measure) Measure Reference and Results template -->
         <templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.1"/>
+        <templateId extension="2019-05-01" root="2.16.840.1.113883.10.20.27.3.17"/>
         <id extension="{{random_id}}" root="1.3.6.1.4.1.115"/>
         <statusCode code="completed"/>
         <!-- Containing isBranch external references -->

--- a/lib/qrda-export/catIII-r2-1/_supplemental_data.mustache
+++ b/lib/qrda-export/catIII-r2-1/_supplemental_data.mustache
@@ -13,7 +13,14 @@
     <value xsi:type="CD" nullFlavor="UNK" />
     {{/unknown_supplemental_value?}}
     {{^unknown_supplemental_value?}}
-    <value xsi:type="CD" code="{{code}}" codeSystem="{{supplemental_data_value_code_system}}"/>
+      {{#payer_code?}}
+        <value xsi:type="CD" nullFlavor="OTH">
+          <translation code="{{{cms_payer_code}}}" codeSystem="2.16.840.1.113883.3.249.12" codeSystemName="CMS Clinical Codes"/>
+        </value>
+      {{/payer_code?}}
+      {{^payer_code?}}
+        <value xsi:type="CD" code="{{code}}" codeSystem="{{supplemental_data_value_code_system}}"/>
+      {{/payer_code?}}
     {{/unknown_supplemental_value?}}
     <entryRelationship typeCode="SUBJ" inversionInd="true">
       <!-- Aggregate Count template -->

--- a/lib/qrda-export/catIII-r2-1/qrda3_r21.mustache
+++ b/lib/qrda-export/catIII-r2-1/qrda3_r21.mustache
@@ -4,7 +4,6 @@
 {{> _header}}
   <component>
     <structuredBody>
-      {{> _reporting_period}}
       {{> _measure_section}}
     </structuredBody>
   </component>    	

--- a/lib/qrda-export/catIII-r2-1/qrda3_r21.rb
+++ b/lib/qrda-export/catIII-r2-1/qrda3_r21.rb
@@ -86,7 +86,7 @@ class Qrda3R21 < Mustache
     PAYER_MAP[self['code']]
   end
 
-  def is_cpcplus?
+  def cpcplus?
     @submission_program == 'CPCPLUS'
   end
 

--- a/lib/qrda-export/catIII-r2-1/qrda3_r21.rb
+++ b/lib/qrda-export/catIII-r2-1/qrda3_r21.rb
@@ -6,6 +6,8 @@ class Qrda3R21 < Mustache
 
   self.template_path = __dir__
 
+  PAYER_MAP = { '1' => 'A', '2' => 'B', '349' => 'D' }.freeze
+
   def initialize(aggregate_results, measures, options = {})
     @aggregate_results = aggregate_results
     @measures = measures
@@ -75,8 +77,21 @@ class Qrda3R21 < Mustache
     when 'SEX'
       [{ tid: '2.16.840.1.113883.10.20.27.3.6', extension: '2016-09-01' }]
     when 'PAYER'
-      [{ tid: '2.16.840.1.113883.10.20.27.3.9', extension: '2016-02-01' }]
+      [{ tid: '2.16.840.1.113883.10.20.27.3.9', extension: '2016-02-01' },
+       { tid: '2.16.840.1.113883.10.20.27.3.18', extension: '2018-05-01' }]
     end
+  end
+
+  def cms_payer_code
+    PAYER_MAP[self['code']]
+  end
+
+  def is_cpcplus?
+    @submission_program == 'CPCPLUS'
+  end
+
+  def payer_code?
+    self['type'] == 'PAYER'
   end
 
   def supplemental_data_code

--- a/lib/qrda-export/catIII-r2-1/qrda3_r21.rb
+++ b/lib/qrda-export/catIII-r2-1/qrda3_r21.rb
@@ -6,7 +6,7 @@ class Qrda3R21 < Mustache
 
   self.template_path = __dir__
 
-  PAYER_MAP = { '1' => 'A', '2' => 'B', '349' => 'D' }.freeze
+  PAYER_MAP = { '1' => 'A', '2' => 'B', '3' => 'D', '4' => 'D', '5' => 'C', '6' => 'C', '7' => 'D', '8' => 'D', '9' => 'D' }.freeze
 
   def initialize(aggregate_results, measures, options = {})
     @aggregate_results = aggregate_results
@@ -83,7 +83,7 @@ class Qrda3R21 < Mustache
   end
 
   def cms_payer_code
-    PAYER_MAP[self['code']]
+    PAYER_MAP[self['code'][0]] || 'D'
   end
 
   def cpcplus?

--- a/lib/qrda-export/catIII-r2-1/qrda_header/_information_recipient.mustache
+++ b/lib/qrda-export/catIII-r2-1/qrda_header/_information_recipient.mustache
@@ -1,0 +1,7 @@
+{{#submission_program}}
+<informationRecipient>
+  <intendedRecipient>
+    <id extension="{{submission_program}}" root="2.16.840.1.113883.3.249.7"/>
+  </intendedRecipient>
+</informationRecipient>
+{{/submission_program}}

--- a/lib/qrda-export/catIII-r2-1/qrda_header/_participant_ehr.mustache
+++ b/lib/qrda-export/catIII-r2-1/qrda_header/_participant_ehr.mustache
@@ -1,0 +1,6 @@
+<participant typeCode="DEV">
+  <associatedEntity classCode="RGPR">
+    <id root="2.16.840.1.113883.3.2074.1" extension="12345abcde67890"/>
+    <code code="129465004" displayName="medical record, device" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT"/>
+  </associatedEntity>
+</participant>

--- a/lib/qrda-export/catIII-r2-1/qrda_header/_participant_location.mustache
+++ b/lib/qrda-export/catIII-r2-1/qrda_header/_participant_location.mustache
@@ -1,0 +1,13 @@
+<participant typeCode="LOC">
+  <associatedEntity classCode="SDLOC">
+    <id root="2.16.840.1.113883.3.249.5.1" extension="T2OR1234" assigningAuthorityName="CMS-CMMI"/>
+    <code code="394730007" displayName="healthcare related organization" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT"/>
+    <addr>
+      <streetAddressLine>202 Burlington Rd.</streetAddressLine>
+      <city>Bedford</city>
+      <state>MA</state>
+      <postalCode>01730</postalCode>
+      <country>US</country>
+    </addr>
+  </associatedEntity>
+</participant>


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
