### PR TITLE
fixed some issues from c1 record sample roundtrip

### DIFF
--- a/lib/qrda-import/base-importers/section_importer.rb
+++ b/lib/qrda-import/base-importers/section_importer.rb
@@ -196,7 +196,7 @@ module QRDA
 
       def extract_scalar(parent_element, scalar_xpath)
         scalar_element = parent_element.at_xpath(scalar_xpath)
-        return unless scalar_element
+        return unless scalar_element && scalar_element['value'].present?
 
         QDM::Quantity.new(scalar_element['value'].to_f, scalar_element['unit'])
       end

--- a/lib/qrda-import/data-element-importers/device_order_importer.rb
+++ b/lib/qrda-import/data-element-importers/device_order_importer.rb
@@ -6,7 +6,7 @@ module QRDA
         @id_xpath = "./cda:entryRelationship/cda:supply[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.9']/cda:id"
         @code_xpath = "./cda:entryRelationship/cda:supply[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.9']/cda:participant/cda:participantRole/cda:playingDevice/cda:code"
         @author_datetime_xpath = "./cda:entryRelationship/cda:supply[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.9']/cda:author/cda:time"
-        @reason_xpath = "./cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value"
+        @reason_xpath = "./cda:entryRelationship/cda:supply[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.9']/cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value"
         @entry_class = QDM::DeviceOrder
       end
 

--- a/lib/qrda-import/data-element-importers/device_recommended_importer.rb
+++ b/lib/qrda-import/data-element-importers/device_recommended_importer.rb
@@ -6,7 +6,7 @@ module QRDA
         @id_xpath = "./cda:entryRelationship/cda:supply[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.10']/cda:id"
         @code_xpath = "./cda:entryRelationship/cda:supply[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.10']/cda:participant/cda:participantRole/cda:playingDevice/cda:code"
         @author_datetime_xpath = "./cda:entryRelationship/cda:supply[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.10']/cda:author/cda:time"
-        @reason_xpath = "./cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value"
+        @reason_xpath = "./cda:entryRelationship/cda:supply[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.10']/cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value"
         @entry_class = QDM::DeviceRecommended
       end
 

--- a/lib/qrda-import/data-element-importers/patient_characteristic_clinical_trial_participant_importer.rb
+++ b/lib/qrda-import/data-element-importers/patient_characteristic_clinical_trial_participant_importer.rb
@@ -6,11 +6,13 @@ module QRDA
         @id_xpath = './cda:id'
         @code_xpath = './cda:value'
         @relevant_period_xpath = "./cda:effectiveTime"
+        @reason_xpath = "./cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value"
         @entry_class = QDM::PatientCharacteristicClinicalTrialParticipant
       end
 
       def create_entry(entry_element, nrh = NarrativeReferenceHandler.new)
         patient_characteristic_clinical_trial_participant = super
+        patient_characteristic_clinical_trial_participant.reason = extract_reason(entry_element)
         patient_characteristic_clinical_trial_participant
       end
 


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
