### PR TITLE
medications in eCQM are always precoordinated, do not export unit

### DIFF
--- a/lib/qrda-export/catI-r5/qrda_templates/template_partials/_immunization_details.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/template_partials/_immunization_details.mustache
@@ -8,7 +8,7 @@
 {{/negated}}
 {{^negated}}
 {{#dosage}}
-<!--  QDM Attribute: Dosage -->
-<doseQuantity value="{{{value_as_float}}}"/>
+  <!--  QDM Attribute: Dosage -->
+  {{{dose_quantity_value}}}
 {{/dosage}}
 {{/negated}}

--- a/lib/qrda-export/catI-r5/qrda_templates/template_partials/_immunization_details.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/template_partials/_immunization_details.mustache
@@ -9,6 +9,6 @@
 {{^negated}}
 {{#dosage}}
 <!--  QDM Attribute: Dosage -->
-<doseQuantity value="{{{value_as_float}}}" unit="{{unit}}"/>
+<doseQuantity value="{{{value_as_float}}}"/>
 {{/dosage}}
 {{/negated}}

--- a/lib/qrda-export/catI-r5/qrda_templates/template_partials/_medication_details.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/template_partials/_medication_details.mustache
@@ -30,8 +30,8 @@
 {{/negated}}
 {{^negated}}
 {{#dosage}}
-<!--  QDM Attribute: Dosage -->
-<doseQuantity value="{{{value_as_float}}}"/>
+  <!--  QDM Attribute: Dosage -->
+  {{{dose_quantity_value}}}
 {{/dosage}}
 {{^dosage}}
 <!--  QDM Attribute: Dosage -->

--- a/lib/qrda-export/catI-r5/qrda_templates/template_partials/_medication_details.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/template_partials/_medication_details.mustache
@@ -31,7 +31,7 @@
 {{^negated}}
 {{#dosage}}
 <!--  QDM Attribute: Dosage -->
-<doseQuantity value="{{{value_as_float}}}" unit="{{unit}}"/>
+<doseQuantity value="{{{value_as_float}}}"/>
 {{/dosage}}
 {{^dosage}}
 <!--  QDM Attribute: Dosage -->

--- a/lib/qrda-export/helper/cat1_view_helper.rb
+++ b/lib/qrda-export/helper/cat1_view_helper.rb
@@ -55,6 +55,11 @@ module Qrda
           self['value'].to_f
         end
 
+        def dose_quantity_value
+          return "<doseQuantity value=\"#{value_as_float}\" unit=\"#{self['unit']}\"/>" if self['unit']
+          "<doseQuantity value=\"#{value_as_float}\" />"
+        end
+
         def result_value
           return "<value xsi:type=\"CD\" nullFlavor=\"UNK\"/>" unless self['result']
 


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-544
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: @mayerm94
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code