### PR TITLE
Use resultdatetime only for effectivetime

### DIFF
--- a/cqm-reports.gemspec
+++ b/cqm-reports.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.authors = ["The MITRE Corporation"]
   s.license = 'Apache-2.0'
 
-  s.version = '3.0.0-alpha.1'
+  s.version = '3.0.0-alpha.2'
 
   s.add_dependency 'cqm-models', '~> 3.0.0'
 

--- a/lib/qrda-export/catI-r5/qrda_templates/template_partials/_results.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/template_partials/_results.mustache
@@ -5,19 +5,7 @@
     <id root="1.3.6.1.4.1.115" extension="{{random_id}}"/>
     {{> _codes}}
     <statusCode code="completed"/>
-    {{#resultDatetime}}
     {{{result_date_time}}}
-    {{/resultDatetime}}
-    {{^resultDatetime}}
-      {{#relevantPeriod}}
-      {{{relevant_period_as_value}}}
-      {{/relevantPeriod}}
-      {{^relevantPeriod}}
-        {{#authorDatetime}}
-        {{{author_effective_time}}}
-        {{/authorDatetime}}
-      {{/relevantPeriod}}
-    {{/resultDatetime}}
     {{{result_value}}}
  </observation>
 </entryRelationship>


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
