### PR TITLE
Changes for null flavor gender race ethnicity

### DIFF
--- a/lib/qrda-export/catI-r5/qrda_header/_record_target.mustache
+++ b/lib/qrda-export/catI-r5/qrda_header/_record_target.mustache
@@ -21,6 +21,9 @@
           <administrativeGenderCode {{> _code}}/>
         {{/dataElementCodes}}
       {{/patient_characteristic_sex}}
+      {{^patient_characteristic_sex}}
+          <administrativeGenderCode nullFlavor="UNK"/>
+      {{/patient_characteristic_sex}}
       {{#patient_characteristic_birthdate}}
         {{{birth_date_time}}}
       {{/patient_characteristic_birthdate}}
@@ -29,10 +32,16 @@
           <raceCode {{> _code}}/>
         {{/dataElementCodes}}
       {{/patient_characteristic_race}}
+      {{^patient_characteristic_race}}
+          <raceCode nullFlavor="UNK"/>
+      {{/patient_characteristic_race}}
       {{#patient_characteristic_ethnicity}}
         {{#dataElementCodes}}
           <ethnicGroupCode {{> _code}}/>
         {{/dataElementCodes}}
+      {{/patient_characteristic_ethnicity}}
+      {{^patient_characteristic_ethnicity}}
+          <ethnicGroupCode nullFlavor="UNK"/>
       {{/patient_characteristic_ethnicity}}
       <languageCommunication>
         <templateId root="2.16.840.1.113883.3.88.11.83.2" assigningAuthorityName="HITSP/C83"/>

--- a/lib/qrda-import/base-importers/demographics_importer.rb
+++ b/lib/qrda-import/base-importers/demographics_importer.rb
@@ -15,17 +15,17 @@ module QRDA
         pcs = QDM::PatientCharacteristicSex.new
         code_element = patient_element.at_xpath('cda:administrativeGenderCode')
         pcs.dataElementCodes = [code_if_present(code_element)]
-        patient.qdmPatient.dataElements << pcs
+        patient.qdmPatient.dataElements << pcs unless pcs.dataElementCodes.compact.blank?
 
         pcr = QDM::PatientCharacteristicRace.new
         code_element = patient_element.at_xpath('cda:raceCode')
         pcr.dataElementCodes = [code_if_present(code_element)]
-        patient.qdmPatient.dataElements << pcr
+        patient.qdmPatient.dataElements << pcr unless pcr.dataElementCodes.compact.blank?
 
         pce = QDM::PatientCharacteristicEthnicity.new
         code_element = patient_element.at_xpath('cda:ethnicGroupCode')
         pce.dataElementCodes = [code_if_present(code_element)]
-        patient.qdmPatient.dataElements << pce
+        patient.qdmPatient.dataElements << pce unless pce.dataElementCodes.compact.blank?
       end
 
       def code_if_present(code_element)


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
