### PR TITLE
Related To is now an array of strings, not ids

### DIFF
--- a/lib/qrda-export/catI-r5/qrda_templates/template_partials/_related_to.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/template_partials/_related_to.mustache
@@ -1,6 +1,6 @@
 <sdtc:inFulfillmentOf1 typeCode="FLFS">
   <sdtc:templateId root="2.16.840.1.113883.10.20.24.3.150" extension="2017-08-01"/>
   <sdtc:actReference classCode="ACT" moodCode="EVN">
-    <sdtc:id root="1.3.6.1.4.1.115" extension="{{{as_id}}}"/>
+    <sdtc:id root="1.3.6.1.4.1.115" extension="{{{.}}}"/>
   </sdtc:actReference>
 </sdtc:inFulfillmentOf1>

--- a/lib/qrda-import/data-element-importers/communication_performed_importer.rb
+++ b/lib/qrda-import/data-element-importers/communication_performed_importer.rb
@@ -22,7 +22,7 @@ module QRDA
         communication_performed.receivedDatetime = extract_time(entry_element, @received_datetime_xpath)
         communication_performed.sender = extract_entity(entry_element, "./cda:participant[@typeCode='AUT']")
         communication_performed.recipient = extract_entity(entry_element, "./cda:participant[@typeCode='IRCP']")
-        # communication_performed.relatedTo = extract_related_to(entry_element)
+        communication_performed.relatedTo = extract_related_to(entry_element)
         communication_performed
       end
     end

--- a/lib/qrda-import/patient_importer.rb
+++ b/lib/qrda-import/patient_importer.rb
@@ -112,11 +112,7 @@ module QRDA
           data_element.relatedTo.each do |related_to|
             relations_to_add += entry_id_map["#{related_to.value}_#{related_to.namingSystem}"]
           end
-          # Clear out relatedTo element. We will be replacing the ids from the QRDA document with our interal ids.
-          data_element.relatedTo = []
-          relations_to_add.each do |relation_to_add|
-            data_element.relatedTo << relation_to_add.to_s
-          end
+          data_element.relatedTo = relations_to_add.map{ |r| r.to_s }
         end
       end
 

--- a/lib/qrda-import/patient_importer.rb
+++ b/lib/qrda-import/patient_importer.rb
@@ -112,7 +112,7 @@ module QRDA
           data_element.relatedTo.each do |related_to|
             relations_to_add += entry_id_map["#{related_to.value}_#{related_to.namingSystem}"]
           end
-          data_element.relatedTo = relations_to_add.map{ |r| r.to_s }
+          data_element.relatedTo = relations_to_add.map(&:to_s)
         end
       end
 

--- a/lib/qrda-import/patient_importer.rb
+++ b/lib/qrda-import/patient_importer.rb
@@ -110,11 +110,12 @@ module QRDA
 
           relations_to_add = []
           data_element.relatedTo.each do |related_to|
-            relations_to_add << entry_id_map["#{related_to.value}_#{related_to.namingSystem}"]
+            relations_to_add += entry_id_map["#{related_to.value}_#{related_to.namingSystem}"]
           end
-          data_element.relatedTo.destroy
+          # Clear out relatedTo element. We will be replacing the ids from the QRDA document with our interal ids.
+          data_element.relatedTo = []
           relations_to_add.each do |relation_to_add|
-            data_element.relatedTo << relation_to_add
+            data_element.relatedTo << relation_to_add.to_s
           end
         end
       end


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
