### PR TITLE
(Temp) Exhastive fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :development do
 end
 
 group :test do
-  gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models', branch: 'randomize_generation'
+  gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models', branch: 'master'
   gem 'factory_girl', '~> 4.1.0'
   gem 'tailor', '~> 1.1.2'
   gem 'cane', '~> 2.3.0'

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :development do
 end
 
 group :test do
-  gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models', branch: 'master'
+  gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models', branch: 'randomize_generation'
   gem 'factory_girl', '~> 4.1.0'
   gem 'tailor', '~> 1.1.2'
   gem 'cane', '~> 2.3.0'

--- a/lib/html-export/qdm-patient/qdm_patient.rb
+++ b/lib/html-export/qdm-patient/qdm_patient.rb
@@ -72,7 +72,7 @@ class QdmPatient < Mustache
     return unit_string if self['value']
     return code_code_system_string if self['code']
 
-    ''
+    self['result']
   end
 
   def nested_code_string

--- a/test/unit/qrda/patient_round_trip_test.rb
+++ b/test/unit/qrda/patient_round_trip_test.rb
@@ -155,7 +155,7 @@ module QRDA
 
       def test_exhaustive_patient_roundtrip
         puts "\n========================= QRDA ROUNDTRIP ========================="
-        cqm_patients = QDM::PatientGeneration.generate_exhastive_data_element_patients(true)
+        cqm_patients = QDM::PatientGeneration.generate_exhaustive_data_element_patients(true)
         add_different_frequency_codes_to_medication(cqm_patients.find { |patient| patient.familyName.include? 'MedicationDispensed' })
         successful_count = 0
         cqm_patients.each do |cqm_patient| 
@@ -213,7 +213,7 @@ module QRDA
       def test_exhaustive_qrda_validation
         skip_types = %w[Entity PatientEntity CarePartner Practitioner Organization CareGoal DiagnosisComponent]
         puts "\n========================= QRDA VALIDATION ========================="
-        cqm_patients = QDM::PatientGeneration.generate_exhastive_data_element_patients(true)
+        cqm_patients = QDM::PatientGeneration.generate_exhaustive_data_element_patients(true)
         add_different_frequency_codes_to_medication(cqm_patients.find { |patient| patient.familyName.include? 'MedicationDispensed' })
         validator = CqmValidators::Cat1R52.instance
         cda_validator = CqmValidators::CDA.instance


### PR DESCRIPTION
Fixes a typo in cqm-models

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
