### PR TITLE
allow string values (#89)

### DIFF
--- a/lib/qrda-export/helper/cat1_view_helper.rb
+++ b/lib/qrda-export/helper/cat1_view_helper.rb
@@ -67,6 +67,8 @@ module Qrda
                             result_value_as_string(self['result'][0])
                           elsif self['result'].is_a? Hash
                             result_value_as_string(self['result'])
+                          elsif self['result'].is_a? String
+                            "<value xsi:type=\"ST\">#{self['result']}</value>"
                           elsif !self['result'].nil?
                             "<value xsi:type=\"PQ\" value=\"#{self['result']}\" unit=\"1\"/>"
                           end

--- a/lib/qrda-import/base-importers/section_importer.rb
+++ b/lib/qrda-import/base-importers/section_importer.rb
@@ -158,7 +158,6 @@ module QRDA
 
       def extract_result_value(value_element)
         return unless value_element && !value_element['nullFlavor']
-
         value = value_element['value']
         if value.present?
           return value.strip.to_f if (value_element['unit'] == "1" || value_element['unit'].nil?)
@@ -166,6 +165,8 @@ module QRDA
           return QDM::Quantity.new(value.strip.to_f, value_element['unit'])
         elsif value_element['code'].present?
           return code_if_present(value_element)
+        elsif value_element.text.present?
+          return value_element.text
         end
       end
 


### PR DESCRIPTION
* allow string values

* export string value as well

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
