### PR TITLE
warning messages with a location

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,5 @@ group :test do
   gem 'minitest', '~> 5.3'
   gem 'minitest-reporters'
   gem 'awesome_print', :require => 'ap'
-  gem 'cqm-validators', git: 'https://github.com/projecttacoma/cqm-validators', branch: 'master'
   gem 'nokogiri-diff'
 end

--- a/cqm-reports.gemspec
+++ b/cqm-reports.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.version = '3.0.0'
 
   s.add_dependency 'cqm-models', '~> 3.0.0'
+  s.add_dependency 'cqm-validators', '~> 3.0.0'
 
   s.add_dependency 'mustache'
 

--- a/lib/qrda-import/base-importers/section_importer.rb
+++ b/lib/qrda-import/base-importers/section_importer.rb
@@ -117,12 +117,14 @@ module QRDA
           # pass warning: current code continues as expected, but adds warning
           id_attr = parent_element.at_xpath(".//cda:id").attributes
           qrda_type = @entry_class.to_s.split("::")[1]
-          @warnings << "Interval with low time after high time. Located in element with QRDA type: #{qrda_type} and id: #{id_attr['root']&.value}(root), #{id_attr['extension']&.value}(extension)."
+          @warnings << ValidationError.new(message: "Interval with low time after high time. Located in element with QRDA type: #{qrda_type} and id: #{id_attr['root']&.value}(root), #{id_attr['extension']&.value}(extension).",
+                                           location: parent_element.path)
         end
         if low_time.nil? && high_time.nil?
           id_attr = parent_element.at_xpath(".//cda:id").attributes
           qrda_type = @entry_class.to_s.split("::")[1]
-          @warnings << "Interval with nullFlavor low time and nullFlavor high time. Located in element with QRDA type: #{qrda_type} and id: #{id_attr['root']&.value}(root), #{id_attr['extension']&.value if id_attr['extension']}(extension)."
+          @warnings << ValidationError.new(message: "Interval with nullFlavor low time and nullFlavor high time. Located in element with QRDA type: #{qrda_type} and id: #{id_attr['root']&.value}(root), #{id_attr['extension']&.value if id_attr['extension']}(extension).",
+                                           location: parent_element.path)
         end
         QDM::Interval.new(low_time, high_time).shift_dates(0)
       end
@@ -181,7 +183,8 @@ module QRDA
         elsif value_element.text.present?
           id_attr = value_element.parent.at_xpath(".//cda:id").attributes
           qrda_type = @entry_class.to_s.split("::")[1]
-          @warnings << "Value with string type found. When possible, it's best practice to use a coded value or scalar. Located in element with QRDA type: #{qrda_type} and id: #{id_attr['root']&.value}(root), #{id_attr['extension']&.value}(extension)."
+          @warnings << ValidationError.new(message: "Value with string type found. When possible, it's best practice to use a coded value or scalar. Located in element with QRDA type: #{qrda_type} and id: #{id_attr['root']&.value}(root), #{id_attr['extension']&.value}(extension).",
+                                           location: value_element.path)
           return value_element.text
         end
       end
@@ -217,7 +220,8 @@ module QRDA
               entry.dataElementCodes = [{ code: "NA", system: '1.2.3.4.5.6.7.8.9.10' }]
               id_attr = parent_element.at_xpath(".//cda:id").attributes
               qrda_type = @entry_class.to_s.split("::")[1]
-              @warnings << "Negated code element contains nullFlavor code but no valueset. Located in element with QRDA type: #{qrda_type} and id: #{id_attr['root']&.value}(root), #{id_attr['extension']&.value}(extension)."
+              @warnings << ValidationError.new(message: "Negated code element contains nullFlavor code but no valueset. Located in element with QRDA type: #{qrda_type} and id: #{id_attr['root']&.value}(root), #{id_attr['extension']&.value}(extension).",
+                                               location: parent_element.path)
             end
           end
         end


### PR DESCRIPTION
pass back ValidationErrors defined in cqm-validators

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
