### PR TITLE
Ignore unit '1'

### DIFF
--- a/lib/html-export/qdm-patient/qdm_patient.rb
+++ b/lib/html-export/qdm-patient/qdm_patient.rb
@@ -25,7 +25,7 @@ class QdmPatient < Mustache
   end
 
   def unit_string
-    return "#{self['value']} " unless self['unit']
+    return "#{self['value']} " if !self['unit'] || self['unit'] == '1'
     "#{self['value']} #{self['unit']}"
   end
 


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
