### PR TITLE
fix assuming attributes have ids for warning message

### DIFF
--- a/lib/qrda-import/base-importers/section_importer.rb
+++ b/lib/qrda-import/base-importers/section_importer.rb
@@ -42,7 +42,7 @@ module QRDA
         # This is the id found in the QRDA file
         entry_qrda_id = extract_id(entry_element, @id_xpath)
         # Create a hash to map all of entry.ids to the same QRDA ids. This will be used to merge QRDA entries
-        # that represent the same event. 
+        # that represent the same event.
         @entry_id_map["#{entry_qrda_id.value}_#{entry_qrda_id.namingSystem}"] ||= []
         @entry_id_map["#{entry_qrda_id.value}_#{entry_qrda_id.namingSystem}"] << entry.id
         entry.dataElementCodes = extract_codes(entry_element, @code_xpath)
@@ -115,15 +115,17 @@ module QRDA
         end
         if low_time && high_time && low_time > high_time
           # pass warning: current code continues as expected, but adds warning
-          id_attr = parent_element.at_xpath(".//cda:id").attributes
+          id_attr = parent_element.at_xpath(".//cda:id")&.attributes
+          id_str = id_attr ? "and id: #{id_attr['root']&.value}(root), #{id_attr['extension']&.value}(extension)" : ""
           qrda_type = @entry_class.to_s.split("::")[1]
-          @warnings << ValidationError.new(message: "Interval with low time after high time. Located in element with QRDA type: #{qrda_type} and id: #{id_attr['root']&.value}(root), #{id_attr['extension']&.value}(extension).",
+          @warnings << ValidationError.new(message: "Interval with low time after high time. Located in element with QRDA type: #{qrda_type} #{id_str}",
                                            location: parent_element.path)
         end
         if low_time.nil? && high_time.nil?
-          id_attr = parent_element.at_xpath(".//cda:id").attributes
+          id_attr = parent_element.at_xpath(".//cda:id")&.attributes
+          id_str = id_attr ? "and id: #{id_attr['root']&.value}(root), #{id_attr['extension']&.value}(extension)" : ""
           qrda_type = @entry_class.to_s.split("::")[1]
-          @warnings << ValidationError.new(message: "Interval with nullFlavor low time and nullFlavor high time. Located in element with QRDA type: #{qrda_type} and id: #{id_attr['root']&.value}(root), #{id_attr['extension']&.value if id_attr['extension']}(extension).",
+          @warnings << ValidationError.new(message: "Interval with nullFlavor low time and nullFlavor high time. Located in element with QRDA type: #{qrda_type} #{id_str}",
                                            location: parent_element.path)
         end
         QDM::Interval.new(low_time, high_time).shift_dates(0)
@@ -168,7 +170,7 @@ module QRDA
         parent_element.xpath(@result_xpath).each do |elem|
           result << extract_result_value(elem)
         end
-        result.size > 1 ? result : result.first 
+        result.size > 1 ? result : result.first
       end
 
       def extract_result_value(value_element)
@@ -181,9 +183,10 @@ module QRDA
         elsif value_element['code'].present?
           return code_if_present(value_element)
         elsif value_element.text.present?
-          id_attr = value_element.parent.at_xpath(".//cda:id").attributes
+          id_attr = value_element.parent.at_xpath(".//cda:id")&.attributes
+          id_str = id_attr ? "and id: #{id_attr['root']&.value}(root), #{id_attr['extension']&.value}(extension)" : ""
           qrda_type = @entry_class.to_s.split("::")[1]
-          @warnings << ValidationError.new(message: "Value with string type found. When possible, it's best practice to use a coded value or scalar. Located in element with QRDA type: #{qrda_type} and id: #{id_attr['root']&.value}(root), #{id_attr['extension']&.value}(extension).",
+          @warnings << ValidationError.new(message: "Value with string type found. When possible, it's best practice to use a coded value or scalar. Located in element with QRDA type: #{qrda_type} #{id_str}",
                                            location: value_element.path)
           return value_element.text
         end
@@ -195,16 +198,16 @@ module QRDA
         negation_indicator = parent_element['negationInd']
         # Return and do not set reason attribute if the entry is negated
         return nil if negation_indicator.eql?('true')
-        
-        reason_element.blank? ? nil : code_if_present(reason_element.first) 
+
+        reason_element.blank? ? nil : code_if_present(reason_element.first)
       end
 
       def extract_negation(parent_element, entry)
         negation_element = parent_element.xpath("./cda:entryRelationship[@typeCode='RSON']/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.88']/cda:value")
         negation_indicator = parent_element['negationInd']
         # Return and do not set negationRationale attribute if the entry is not negated
-        return unless negation_indicator.eql?('true') 
-        
+        return unless negation_indicator.eql?('true')
+
         entry.negationRationale = code_if_present(negation_element.first) unless negation_element.blank?
         extract_negated_code(parent_element, entry)
       end
@@ -218,9 +221,10 @@ module QRDA
             else
               # negated code is nullFlavored with no valueset
               entry.dataElementCodes = [{ code: "NA", system: '1.2.3.4.5.6.7.8.9.10' }]
-              id_attr = parent_element.at_xpath(".//cda:id").attributes
+              id_attr = parent_element.at_xpath(".//cda:id")&.attributes
+              id_str = id_attr ? "and id: #{id_attr['root']&.value}(root), #{id_attr['extension']&.value}(extension)" : ""
               qrda_type = @entry_class.to_s.split("::")[1]
-              @warnings << ValidationError.new(message: "Negated code element contains nullFlavor code but no valueset. Located in element with QRDA type: #{qrda_type} and id: #{id_attr['root']&.value}(root), #{id_attr['extension']&.value}(extension).",
+              @warnings << ValidationError.new(message: "Negated code element contains nullFlavor code but no valueset. Located in element with QRDA type: #{qrda_type} #{id_str}.",
                                                location: parent_element.path)
             end
           end


### PR DESCRIPTION
New message when id doesn't exist:
<img width="804" alt="Screen Shot 2020-07-16 at 5 19 36 PM" src="https://user-images.githubusercontent.com/2643955/87724277-285f4280-c789-11ea-8a10-7e7da8e9580f.png">

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
