### PR TITLE
MAT1528_escape_special_chars_rt_given_name

### DIFF
--- a/lib/html-export/qdm-patient/qdm_patient.mustache
+++ b/lib/html-export/qdm-patient/qdm_patient.mustache
@@ -3,7 +3,7 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     {{#patient}}
-    <title>Cypress Certification Patient Test Record: {{{given_name}}} {{familyName}}</title>
+    <title>Cypress Certification Patient Test Record: {{given_name}} {{familyName}}</title>
     {{/patient}}
     {{#include_style?}}
       {{> _header_css}}
@@ -11,12 +11,12 @@
   </head>
   <body>
     {{#patient}}
-    <h1 class="h1center">Cypress Certification Patient Test Record: {{{given_name}}} {{familyName}}</h1>
+    <h1 class="h1center">Cypress Certification Patient Test Record: {{given_name}} {{familyName}}</h1>
     <div class="div-table">
       <div class="div-table-body">
         <div class="div-head-row patient_narr_tr panel panel-default patient-details">
           <div class="div-table-head patient_narr_th panel-heading"><span class="td_label">Patient</span></div>
-          <div class="div-table-head">{{{given_name}}} {{familyName}}</div>
+          <div class="div-table-head">{{given_name}} {{familyName}}</div>
           <div class="div-table-head patient_narr_th panel-heading"><span class="td_label">Sex</span></div>
           <div class="div-table-head">{{{gender}}}</div>
         </div>
@@ -31,7 +31,7 @@
           <div class="div-table-head">{{{race}}}</div>
           <div class="div-table-head patient_narr_th panel-heading"><span class="td_label">Ethnicity</span></div>
           <div class="div-table-head">{{{ethnic_group}}}</div>
-        </div>  
+        </div>
         <div class="div-head-row patient_narr_tr panel panel-default patient-details">
           <div class="div-table-head patient_narr_th panel-heading"><span class="td_label">Insurance Providers</span></div>
           <div class="div-table-head">{{{payer}}}</div>

--- a/lib/qrda-export/catI-r5/qrda_header/_record_target.mustache
+++ b/lib/qrda-export/catI-r5/qrda_header/_record_target.mustache
@@ -18,7 +18,7 @@
     <patient>
       {{#patient}}
         <name>
-          <given>{{{given_name}}}</given>
+          <given>{{given_name}}</given>
           <family>{{familyName}}</family>
         </name>
       {{/patient}}


### PR DESCRIPTION
change given_name template binding syntax from 3 -> 2 curley braces to enable moustache's built in escaping

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.cms.gov/browse/MAT-1528
- [x] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [x] (N/A)Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
