### PR TITLE
Build code set and display patient code descriptions support

### DIFF
--- a/lib/html-export/qdm-patient/data_element/_data_element_codes.mustache
+++ b/lib/html-export/qdm-patient/data_element/_data_element_codes.mustache
@@ -2,7 +2,7 @@
 <div class="div-table-body">
 {{#dataElementCodes}}
 <div class="div-head-row">
-	<div class="div-table-head--no-border"><span class="criteria-heading">{{{code_system_name}}}:</span>  {{code}}</div>
+	<div class="div-table-head--no-border"><span class="criteria-heading">{{{code_system_name}}}:</span>  {{code}}{{{code_description}}}</div>
 </div>
 {{/dataElementCodes}}
 </div>

--- a/lib/html-export/qdm-patient/qdm_patient.mustache
+++ b/lib/html-export/qdm-patient/qdm_patient.mustache
@@ -18,7 +18,7 @@
           <div class="div-table-head patient_narr_th panel-heading"><span class="td_label">Patient</span></div>
           <div class="div-table-head">{{given_name}} {{familyName}}</div>
           <div class="div-table-head patient_narr_th panel-heading"><span class="td_label">Sex</span></div>
-          <div class="div-table-head">{{{gender}}}</div>
+          <div class="div-table-head">{{{gender}}}{{#demographic_code_description}}gender{{/demographic_code_description}}</div>
         </div>
         <div class="div-head-row patient_narr_tr panel panel-default patient-details">
           <div class="div-table-head patient_narr_th panel-heading"><span class="td_label">Date of birth</span></div>
@@ -28,13 +28,13 @@
         </div>
         <div class="div-head-row patient_narr_tr panel panel-default patient-details">
           <div class="div-table-head patient_narr_th panel-heading"><span class="td_label">Race</span></div>
-          <div class="div-table-head">{{{race}}}</div>
+          <div class="div-table-head">{{{race}}}{{#demographic_code_description}}race{{/demographic_code_description}}</div>
           <div class="div-table-head patient_narr_th panel-heading"><span class="td_label">Ethnicity</span></div>
-          <div class="div-table-head">{{{ethnic_group}}}</div>
+          <div class="div-table-head">{{{ethnic_group}}}{{#demographic_code_description}}ethnic_group{{/demographic_code_description}}</div>
         </div>
         <div class="div-head-row patient_narr_tr panel panel-default patient-details">
           <div class="div-table-head patient_narr_th panel-heading"><span class="td_label">Insurance Providers</span></div>
-          <div class="div-table-head">{{{payer}}}</div>
+          <div class="div-table-head">{{{payer}}}{{#demographic_code_description}}payer{{/demographic_code_description}}</div>
           <div class="div-table-head patient_narr_th panel-heading"><span class="td_label">Patient IDs</span></div>
           <div class="div-table-head">{{{mrn}}} Cypress</div>
         </div>

--- a/lib/html-export/qdm-patient/qdm_patient.rb
+++ b/lib/html-export/qdm-patient/qdm_patient.rb
@@ -91,17 +91,17 @@ class QdmPatient < Mustache
   end
 
   def code_for_element(element)
-    "#{element['code']} (#{HQMF::Util::CodeSystemHelper.code_system_for(element['system'])})#{code_description}"
+    "#{element['code']} (#{HQMF::Util::CodeSystemHelper.code_system_for(element['system'])})#{code_description(element)}"
   end
 
   def code_system_name
     HQMF::Util::CodeSystemHelper.code_system_for(self['system'])
   end
 
-  def code_description
+  def code_description(element = self)
     has_descriptions = @patient.respond_to?(:code_description_hash) && !@patient.code_description_hash.empty?
     # mongo keys cannot contain '.', so replace all '.', key example: '21112-8:2_16_840_1_113883_6_1'
-    return " - #{@patient.code_description_hash["#{self['code']}:#{self['system'].gsub('.','_')}"]}" if has_descriptions
+    return " - #{@patient.code_description_hash["#{element['code']}:#{element['system'].tr('.', '_')}"]}" if has_descriptions
     # no code description available
     ""
   end

--- a/lib/html-export/qdm-patient/qdm_patient.rb
+++ b/lib/html-export/qdm-patient/qdm_patient.rb
@@ -106,24 +106,11 @@ class QdmPatient < Mustache
     ""
   end
 
-  def demographic_code_description(type)
+  def demographic_code_description(code)
     # only have code, don't need code system
-    code = case type
-    when 'race'
-        race
-      when 'ethnic_group'
-        ethnic_group
-      when 'gender'
-        gender
-      when 'payer'
-        payer
-      else
-        ""
-    end
-
     has_descriptions = code && @patient.respond_to?(:code_description_hash) && !@patient.code_description_hash.empty?
     if has_descriptions
-      key = @patient.code_description_hash.keys.detect{ |k| k.starts_with?("#{code}:") }
+      key = @patient.code_description_hash.keys.detect { |k| k.starts_with?("#{send(code)}:") }
       return " - #{@patient.code_description_hash[key]}"
     end
     ""

--- a/lib/html-export/qdm-patient/qdm_patient.rb
+++ b/lib/html-export/qdm-patient/qdm_patient.rb
@@ -91,11 +91,19 @@ class QdmPatient < Mustache
   end
 
   def code_for_element(element)
-    "#{element['code']} (#{HQMF::Util::CodeSystemHelper.code_system_for(element['system'])})"
+    "#{element['code']} (#{HQMF::Util::CodeSystemHelper.code_system_for(element['system'])})#{code_description}"
   end
 
   def code_system_name
     HQMF::Util::CodeSystemHelper.code_system_for(self['system'])
+  end
+
+  def code_description
+    has_descriptions = @patient.respond_to?(:code_description_hash) && !@patient.code_description_hash.empty?
+    # mongo keys cannot contain '.', so replace all '.', key example: '21112-8:2_16_840_1_113883_6_1'
+    return " - #{@patient.code_description_hash["#{self['code']}:#{self['system'].gsub('.','_')}"]}" if has_descriptions
+    # no code description available
+    ""
   end
 
   def result_string

--- a/lib/html-export/qdm-patient/qdm_patient.rb
+++ b/lib/html-export/qdm-patient/qdm_patient.rb
@@ -106,6 +106,29 @@ class QdmPatient < Mustache
     ""
   end
 
+  def demographic_code_description(type)
+    # only have code, don't need code system
+    code = case type
+    when 'race'
+        race
+      when 'ethnic_group'
+        ethnic_group
+      when 'gender'
+        gender
+      when 'payer'
+        payer
+      else
+        ""
+    end
+
+    has_descriptions = code && @patient.respond_to?(:code_description_hash) && !@patient.code_description_hash.empty?
+    if has_descriptions
+      key = @patient.code_description_hash.keys.detect{ |k| k.starts_with?("#{code}:") }
+      return " - #{@patient.code_description_hash[key]}"
+    end
+    ""
+  end
+
   def result_string
     return unit_string if self['value']
     return code_code_system_string if self['code']

--- a/lib/html-export/qdm-patient/qdm_patient.rb
+++ b/lib/html-export/qdm-patient/qdm_patient.rb
@@ -101,7 +101,7 @@ class QdmPatient < Mustache
   def code_description(element = self)
     has_descriptions = @patient.respond_to?(:code_description_hash) && !@patient.code_description_hash.empty?
     # mongo keys cannot contain '.', so replace all '.', key example: '21112-8:2_16_840_1_113883_6_1'
-    return " - #{@patient.code_description_hash["#{element['code']}:#{element['system'].tr('.', '_')}"]}" if has_descriptions
+    return " - #{@patient.code_description_hash["#{element['code']}:#{element['system']}".tr('.', '_')]}" if has_descriptions
     # no code description available
     ""
   end

--- a/lib/qrda-import/base-importers/demographics_importer.rb
+++ b/lib/qrda-import/base-importers/demographics_importer.rb
@@ -1,7 +1,7 @@
 module QRDA
   module Cat1
     module DemographicsImporter
-      def get_demographics(patient, doc)
+      def get_demographics(patient, doc, codes)
         patient_role_element = doc.at_xpath('/cda:ClinicalDocument/cda:recordTarget/cda:patientRole')
         patient_element = patient_role_element.at_xpath('./cda:patient')
         patient.givenNames = [patient_element.at_xpath('cda:name/cda:given').text]
@@ -9,28 +9,29 @@ module QRDA
         patient.qdmPatient.birthDatetime = DateTime.parse(patient_element.at_xpath('cda:birthTime')['value'])
         pcbd = QDM::PatientCharacteristicBirthdate.new
         pcbd.birthDatetime = patient.qdmPatient.birthDatetime
-        pcbd.dataElementCodes = [{ code: '21112-8', system: '2.16.840.1.113883.6.1' }]
+        pcbd.dataElementCodes = [QDM::Code.new('21112-8', '2.16.840.1.113883.6.1')]
+        codes.add("21112-8:2.16.840.1.113883.6.1")
         patient.qdmPatient.dataElements << pcbd
 
         pcs = QDM::PatientCharacteristicSex.new
         code_element = patient_element.at_xpath('cda:administrativeGenderCode')
-        pcs.dataElementCodes = [code_if_present(code_element)]
+        pcs.dataElementCodes = [code_if_present(code_element, codes)]
         patient.qdmPatient.dataElements << pcs unless pcs.dataElementCodes.compact.blank?
 
         pcr = QDM::PatientCharacteristicRace.new
         code_element = patient_element.at_xpath('cda:raceCode')
-        pcr.dataElementCodes = [code_if_present(code_element)]
+        pcr.dataElementCodes = [code_if_present(code_element, codes)]
         patient.qdmPatient.dataElements << pcr unless pcr.dataElementCodes.compact.blank?
 
         pce = QDM::PatientCharacteristicEthnicity.new
         code_element = patient_element.at_xpath('cda:ethnicGroupCode')
-        pce.dataElementCodes = [code_if_present(code_element)]
+        pce.dataElementCodes = [code_if_present(code_element, codes)]
         patient.qdmPatient.dataElements << pce unless pce.dataElementCodes.compact.blank?
       end
 
-      def code_if_present(code_element)
+      def code_if_present(code_element, codes)
         return unless code_element && code_element['code'] && code_element['codeSystem']
-
+        codes.add("#{code_element['code']}:#{code_element['codeSystem']}")
         QDM::Code.new(code_element['code'], code_element['codeSystem'])
       end
     end

--- a/lib/qrda-import/base-importers/section_importer.rb
+++ b/lib/qrda-import/base-importers/section_importer.rb
@@ -1,7 +1,7 @@
 module QRDA
   module Cat1
     class SectionImporter
-      attr_accessor :check_for_usable, :status_xpath, :code_xpath, :warnings
+      attr_accessor :check_for_usable, :status_xpath, :code_xpath, :warnings, :codes
 
       def initialize(entry_finder)
         @entry_finder = entry_finder
@@ -10,6 +10,7 @@ module QRDA
         @check_for_usable = true
         @entry_class = QDM::DataElement
         @warnings = []
+        @codes = Set.new
       end
 
       # Traverses an HL7 CDA document passed in and creates an Array of Entry
@@ -81,6 +82,7 @@ module QRDA
 
       def code_if_present(code_element)
         return unless code_element && code_element['code'] && code_element['codeSystem']
+        @codes.add("#{code_element['code']}:#{code_element['codeSystem']}")
         QDM::Code.new(code_element['code'], code_element['codeSystem'])
       end
 
@@ -145,6 +147,7 @@ module QRDA
         # If a Direct Reference Code isn't found, return nil
         return nil unless key
         # If a Direct Reference Code is found, return that code
+        @codes.add("#{key}:#{value[:code_system]}")
         QDM::Code.new(key, value[:code_system])
       end
 

--- a/lib/qrda-import/patient_importer.rb
+++ b/lib/qrda-import/patient_importer.rb
@@ -72,7 +72,7 @@ module QRDA
         [patient, warnings, codes]
       end
 
-      def import_data_elements(patient, doc, entry_id_map, codes = [], warnings = [])
+      def import_data_elements(patient, doc, entry_id_map, codes = Set.new, warnings = [])
         context = doc.xpath("/cda:ClinicalDocument/cda:component/cda:structuredBody/cda:component/cda:section[cda:templateId/@root = '2.16.840.1.113883.10.20.24.2.1']")
         nrh = NarrativeReferenceHandler.new
         nrh.build_id_map(doc)

--- a/lib/qrda-import/patient_importer.rb
+++ b/lib/qrda-import/patient_importer.rb
@@ -64,14 +64,15 @@ module QRDA
       def parse_cat1(doc)
         patient = CQM::Patient.new
         warnings = []
+        codes = Set.new
         entry_id_map = {}
-        import_data_elements(patient, doc, entry_id_map, warnings)
+        import_data_elements(patient, doc, entry_id_map, codes, warnings)
         normalize_references(patient, entry_id_map)
-        get_demographics(patient, doc)
-        [patient, warnings]
+        get_demographics(patient, doc, codes)
+        [patient, warnings, codes]
       end
 
-      def import_data_elements(patient, doc, entry_id_map, warnings = [])
+      def import_data_elements(patient, doc, entry_id_map, codes = [], warnings = [])
         context = doc.xpath("/cda:ClinicalDocument/cda:component/cda:structuredBody/cda:component/cda:section[cda:templateId/@root = '2.16.840.1.113883.10.20.24.2.1']")
         nrh = NarrativeReferenceHandler.new
         nrh.build_id_map(doc)
@@ -109,8 +110,10 @@ module QRDA
           patient.qdmPatient.dataElements << new_data_elements
           entry_id_map.merge!(id_map)
           warnings.concat(importer.warnings)
-          # reset warnings after they're captured so that the importer can be re-used
+          codes.merge(importer.codes)
+          # reset warnings and codes after they're captured so that the importer can be re-used
           importer.warnings = []
+          importer.codes = Set.new
         end
       end
 

--- a/test/fixtures/qrda/single_encounter.xml
+++ b/test/fixtures/qrda/single_encounter.xml
@@ -40,8 +40,8 @@
         </name>
         <administrativeGenderCode code="F" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7 AdministrativeGender"/>
         <birthTime value="19690225171500"/>
-        <raceCode code="" codeSystem="2.16.840.1.113883.6.238" codeSystemName="CDC Race and Ethnicity"/>
-        <ethnicGroupCode code="" codeSystem="2.16.840.1.113883.6.238" codeSystemName="CDC Race and Ethnicity"/>
+        <raceCode code="2106-3" codeSystem="2.16.840.1.113883.6.238" codeSystemName="CDC Race and Ethnicity"/>
+        <ethnicGroupCode code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="CDC Race and Ethnicity"/>
         <languageCommunication>
           <templateId assigningAuthorityName="HITSP/C83" root="2.16.840.1.113883.3.88.11.83.2"/>
           <templateId assigningAuthorityName="IHE/PCC" root="1.3.6.1.4.1.19376.1.5.3.1.2.1"/>

--- a/test/unit/qrda/patient_importer_test.rb
+++ b/test/unit/qrda/patient_importer_test.rb
@@ -81,6 +81,29 @@ module QRDA
         @importer.import_data_elements(@patient, doc, @map)
         assert_equal 2, @patient.qdmPatient.dataElements.length
       end
+
+      def test_import_with_code
+        doc = Nokogiri::XML(File.read('test/fixtures/qrda/single_encounter.xml'))
+        doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+        doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
+        codes = Set.new
+        @importer.import_data_elements(@patient, doc, @map, codes)
+        # check for fixture entry's code 99203
+        assert_equal codes.first, "99203:2.16.840.1.113883.6.12"
+      end
+
+      def test_demographics_import_with_code
+        doc = Nokogiri::XML(File.read('test/fixtures/qrda/single_encounter.xml'))
+        doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+        doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
+        codes = Set.new
+        # check demographic codes captured
+        @importer.get_demographics(@patient, doc, codes)
+        assert codes.include?("21112-8:2.16.840.1.113883.6.1"), "Should find birthdate code"
+        assert codes.include?("F:2.16.840.1.113883.5.1"), "Should find gender code"
+        assert codes.include?("2106-3:2.16.840.1.113883.6.238"), "Should find race code"
+        assert codes.include?("2186-5:2.16.840.1.113883.6.238"), "Should find ethnicity code"
+      end
     end
   end
 end


### PR DESCRIPTION
…build set of codes for imported patients and use patient's code descriptions for html export

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
