### PR TITLE
lengthOfStay needs to be calculated as day boundary crossings

### DIFF
--- a/lib/qrda-import/data-element-importers/encounter_performed_importer.rb
+++ b/lib/qrda-import/data-element-importers/encounter_performed_importer.rb
@@ -21,7 +21,7 @@ module QRDA
         encounter_performed.facilityLocations = extract_facility_locations(entry_element)
         encounter_performed.diagnoses = extract_diagnoses(entry_element)
         if encounter_performed&.relevantPeriod&.low && encounter_performed&.relevantPeriod&.high
-          los = encounter_performed.relevantPeriod.high - encounter_performed.relevantPeriod.low
+          los = encounter_performed.relevantPeriod.high.to_date - encounter_performed.relevantPeriod.low.to_date
           encounter_performed.lengthOfStay = QDM::Quantity.new(los.to_i, 'd')
         end
         encounter_performed.participant = extract_entity(entry_element, "./cda:entryRelationship/cda:encounter//cda:participant[@typeCode='PRF']")

--- a/test/fixtures/qrda/single_encounter.xml
+++ b/test/fixtures/qrda/single_encounter.xml
@@ -271,7 +271,7 @@
                   <statusCode code="completed"/>
                   <effectiveTime>
                     <low value="20120709080000"/>
-                    <high value="20120709081500"/>
+                    <high value="20120710071500"/>
                   </effectiveTime>
                 </encounter>
               </entryRelationship>

--- a/test/unit/qrda/patient_importer_test.rb
+++ b/test/unit/qrda/patient_importer_test.rb
@@ -15,6 +15,11 @@ module QRDA
         doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
         doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
         @importer.import_data_elements(@patient, doc, @map)
+
+        encounter = @patient.qdmPatient.encounters.first
+        # lengthOfStay needs to be calculated as day boundary crossings.  The fixture encounter is 23 hours, but crosses the day boundary.
+        assert_equal 1, encounter.lengthOfStay.value
+
         assert_equal 1, @patient.qdmPatient.dataElements.length
       end
 


### PR DESCRIPTION
lengthOfStay needs to be calculated as day boundary crossings.  Currently, the lengthOfStay calculation on QRDA import is doing the DurationBetween calculation (number of whole calendar periods for the specified precision between the first and second arguments) and not the DifferenceBetween calculation.

https://oncprojectracking.healthit.gov/support/browse/CYPRESS-2079

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-748
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
