### PR TITLE
MAT-1308_upgrade_cqm_models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :development do
 end
 
 group :test do
-  gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models', branch: 'master'
+  gem 'cqm-models', '~> 3.0.2'
   gem 'factory_girl', '~> 4.1.0'
   gem 'tailor', '~> 1.1.2'
   gem 'cane', '~> 2.3.0'

--- a/cqm-reports.gemspec
+++ b/cqm-reports.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.version = '3.1.1'
 
-  s.add_dependency 'cqm-models', '~> 3.0.0'
+  s.add_dependency 'cqm-models', '~> 3.0.2'
   s.add_dependency 'cqm-validators', '~> 3.0.0'
 
   s.add_dependency 'mustache'


### PR DESCRIPTION
set version in gemfile and gemspec to 3.0.2

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
