### PR TITLE
"Interval with nullFlavor low time and nullFlavor high time" error sh…

### DIFF
--- a/lib/qrda-import/base-importers/section_importer.rb
+++ b/lib/qrda-import/base-importers/section_importer.rb
@@ -92,7 +92,9 @@ module QRDA
       end
 
       def extract_interval(parent_element, interval_xpath)
-        return nil unless parent_element.at_xpath(interval_xpath)
+        # nil if the time interval does not exist
+        return nil unless time_interval_exists(parent_element, interval_xpath)
+
         if parent_element.at_xpath("#{interval_xpath}/@value")
           low_time = DateTime.parse(parent_element.at_xpath(interval_xpath)['value'])
           high_time = DateTime.parse(parent_element.at_xpath(interval_xpath)['value'])
@@ -127,6 +129,14 @@ module QRDA
                                            location: parent_element.path)
         end
         QDM::Interval.new(low_time, high_time).shift_dates(0)
+      end
+
+      def time_interval_exists(parent_element, interval_xpath)
+        # false if the time interval does not exist
+        return false unless parent_element.at_xpath(interval_xpath)
+        # false if the time element exists but has a null Flavor
+        return false if parent_element.at_xpath(interval_xpath)['nullFlavor']
+        true
       end
 
       def extract_time(parent_element, datetime_xpath)


### PR DESCRIPTION
…ould not be returned when entire element is nullFlavored

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/CYPRESS-2106
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
