### PR TITLE
cqm-reports v3 Telehealth support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,10 @@ Metrics/MethodLength:
     - 'test/unit/qrda/patient_round_trip_test.rb'
     - 'lib/qrda-import/patient_importer.rb'
 
+Metrics/ParameterLists:
+  Exclude:
+    - 'lib/qrda-import/patient_importer.rb'
+
 Documentation:
   Enabled: false
 Style/DateTime:

--- a/lib/qrda-import/base-importers/section_importer.rb
+++ b/lib/qrda-import/base-importers/section_importer.rb
@@ -1,7 +1,7 @@
 module QRDA
   module Cat1
     class SectionImporter
-      attr_accessor :check_for_usable, :status_xpath, :code_xpath, :warnings, :codes
+      attr_accessor :check_for_usable, :status_xpath, :code_xpath, :warnings, :codes, :codes_modifiers
 
       def initialize(entry_finder)
         @entry_finder = entry_finder
@@ -11,6 +11,7 @@ module QRDA
         @entry_class = QDM::DataElement
         @warnings = []
         @codes = Set.new
+        @codes_modifiers = {}
       end
 
       # Traverses an HL7 CDA document passed in and creates an Array of Entry

--- a/lib/qrda-import/data-element-importers/encounter_performed_importer.rb
+++ b/lib/qrda-import/data-element-importers/encounter_performed_importer.rb
@@ -25,10 +25,20 @@ module QRDA
           encounter_performed.lengthOfStay = QDM::Quantity.new(los.to_i, 'd')
         end
         encounter_performed.participant = extract_entity(entry_element, "./cda:entryRelationship/cda:encounter//cda:participant[@typeCode='PRF']")
+        extract_modifier_code(encounter_performed, entry_element)
         encounter_performed
       end
 
       private
+
+      def extract_modifier_code(encounter_performed, entry_element)
+        code_element = entry_element.at_xpath(@code_xpath)
+        return unless code_element
+
+        qualifier_name = code_element.at_xpath('./cda:qualifier/cda:name')
+        qualifier_value = code_element.at_xpath('./cda:qualifier/cda:value')
+        codes_modifiers[encounter_performed.id] = { name: code_if_present(qualifier_name), value: code_if_present(qualifier_value), xpath_location: entry_element.path } if qualifier_value || qualifier_name
+      end
 
       def extract_diagnoses(parent_element)
         diagnosis_elements = parent_element.xpath(@diagnosis_xpath)

--- a/test/unit/qrda/patient_importer_test.rb
+++ b/test/unit/qrda/patient_importer_test.rb
@@ -8,13 +8,15 @@ module QRDA
         @importer = Cat1::PatientImporter.instance
         @patient = CQM::Patient.new
         @map = {}
+        @set = Set.new
+        @codes_modifiers = {}
       end
 
       def test_import_with_single_encounter
         doc = Nokogiri::XML(File.read('test/fixtures/qrda/single_encounter.xml'))
         doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
         doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
-        @importer.import_data_elements(@patient, doc, @map)
+        @importer.import_data_elements(@patient, doc, @map, @set, @codes_modifiers)
 
         encounter = @patient.qdmPatient.encounters.first
         # lengthOfStay needs to be calculated as day boundary crossings.  The fixture encounter is 23 hours, but crosses the day boundary.
@@ -27,7 +29,7 @@ module QRDA
         doc = Nokogiri::XML(File.read('test/fixtures/qrda/two_encounters.xml'))
         doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
         doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
-        @importer.import_data_elements(@patient, doc, @map)
+        @importer.import_data_elements(@patient, doc, @map, @set, @codes_modifiers)
         assert_equal 2, @patient.qdmPatient.dataElements.length
       end
 
@@ -35,7 +37,7 @@ module QRDA
         doc = Nokogiri::XML(File.read('test/fixtures/qrda/two_encounters_same_id_different_codes_same_time.xml'))
         doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
         doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
-        @importer.import_data_elements(@patient, doc, @map)
+        @importer.import_data_elements(@patient, doc, @map, @set, @codes_modifiers)
         assert_equal 2, @patient.qdmPatient.dataElements.length
       end
 
@@ -43,7 +45,7 @@ module QRDA
         doc = Nokogiri::XML(File.read('test/fixtures/qrda/two_encounters_same_id_same_codes_different_time.xml'))
         doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
         doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
-        @importer.import_data_elements(@patient, doc, @map)
+        @importer.import_data_elements(@patient, doc, @map, @set, @codes_modifiers)
         assert_equal 2, @patient.qdmPatient.dataElements.length
       end
 
@@ -51,7 +53,7 @@ module QRDA
         doc = Nokogiri::XML(File.read('test/fixtures/qrda/two_encounters_same_id_same_codes_same_time.xml'))
         doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
         doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
-        @importer.import_data_elements(@patient, doc, @map)
+        @importer.import_data_elements(@patient, doc, @map, @set, @codes_modifiers)
         assert_equal 1, @patient.qdmPatient.dataElements.length
       end
 
@@ -59,7 +61,7 @@ module QRDA
         doc = Nokogiri::XML(File.read('test/fixtures/qrda/two_encounters_same_id_same_two_codes_same_time.xml'))
         doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
         doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
-        @importer.import_data_elements(@patient, doc, @map)
+        @importer.import_data_elements(@patient, doc, @map, @set, @codes_modifiers)
         assert_equal 1, @patient.qdmPatient.dataElements.length
       end
 
@@ -67,7 +69,7 @@ module QRDA
         doc = Nokogiri::XML(File.read('test/fixtures/qrda/two_interventions_with_same_id.xml'))
         doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
         doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
-        @importer.import_data_elements(@patient, doc, @map)
+        @importer.import_data_elements(@patient, doc, @map, @set, @codes_modifiers)
         assert_equal 1, @patient.qdmPatient.dataElements.length
       end
 
@@ -75,7 +77,7 @@ module QRDA
         doc = Nokogiri::XML(File.read('test/fixtures/qrda/two_interventions_with_different_id.xml'))
         doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
         doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
-        @importer.import_data_elements(@patient, doc, @map)
+        @importer.import_data_elements(@patient, doc, @map, @set, @codes_modifiers)
         assert_equal 2, @patient.qdmPatient.dataElements.length
       end
 
@@ -83,7 +85,7 @@ module QRDA
         doc = Nokogiri::XML(File.read('test/fixtures/qrda/two_data_types_with_same_id.xml'))
         doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
         doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
-        @importer.import_data_elements(@patient, doc, @map)
+        @importer.import_data_elements(@patient, doc, @map, @set, @codes_modifiers)
         assert_equal 2, @patient.qdmPatient.dataElements.length
       end
 


### PR DESCRIPTION
* support passing back warnings from import

* Add resilience for missing time values

* one more safe navigation .low

Co-authored-by: lmd59 <lmd59@cornell.edu>

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
