### PR TITLE
if an encounter id exists, export it for physical_exams and lab_tests

### DIFF
--- a/lib/qrda-export/catI-r5/qrda_templates/laboratory_test_performed.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/laboratory_test_performed.mustache
@@ -41,5 +41,9 @@
       <!-- QDM Attribute: Components -->
       {{> qrda_templates/template_partials/_component}}
     {{/components}}
+    {{#encounter_id}}
+      <!-- QDM Attribute: relatedTo -->
+      {{> qrda_templates/template_partials/_related_to}}
+    {{/encounter_id}}
     </observation>
 </entry>

--- a/lib/qrda-export/catI-r5/qrda_templates/physical_exam_performed.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/physical_exam_performed.mustache
@@ -48,5 +48,9 @@
       <!-- QDM Attribute: Components -->
       {{> qrda_templates/template_partials/_component}}
     {{/components}}
+    {{#encounter_id}}
+      <!-- QDM Attribute: relatedTo -->
+      {{> qrda_templates/template_partials/_related_to}}
+    {{/encounter_id}}
   </observation>
 </entry>


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
