### PR TITLE
QRDA Export Not Handling Relevant DateTime/Period Accurately

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [2.3, 2.4, 2.5, 2.6]
+        ruby-version: [2.5, 2.6]
         mongodb-version: [4.0.18, 4.4]
 
     steps:

--- a/cqm-reports.gemspec
+++ b/cqm-reports.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'erubis', '~> 2.7'
   s.add_dependency 'mongoid-tree', '> 2.0'
 
-  s.add_dependency 'nokogiri', '~> 1.10'
+  s.add_dependency 'nokogiri', '~> 1.11'
   s.add_dependency 'uuid', '~> 2.3'
 
   s.add_dependency 'zip-zip', '~> 0.3'

--- a/lib/qrda-export/helper/date_helper.rb
+++ b/lib/qrda-export/helper/date_helper.rb
@@ -101,7 +101,7 @@ module Qrda
         end
 
         def relevant_date_period_or_null_flavor
-          return relevant_period if self['relevantPeriod']
+          return relevant_period unless self['relevantPeriod']['low'].nil? && self['relevantPeriod']['high'].nil?
           return relevant_date_time_value if self['relevantDatetime']
           "<effectiveTime nullFlavor='UNK'/>"
         end

--- a/lib/qrda-export/helper/date_helper.rb
+++ b/lib/qrda-export/helper/date_helper.rb
@@ -101,7 +101,7 @@ module Qrda
         end
 
         def relevant_date_period_or_null_flavor
-          return relevant_period unless self['relevantPeriod']['low'].nil? && self['relevantPeriod']['high'].nil?
+          return relevant_period if self['relevantPeriod'] && (self['relevantPeriod']['low'] || self['relevantPeriod']['high'])
           return relevant_date_time_value if self['relevantDatetime']
           "<effectiveTime nullFlavor='UNK'/>"
         end


### PR DESCRIPTION
QRDA Export Not Handling Relevant DateTime/Period Accurately
- if relevantPeriod is null or both low and high are null, then check relevantDateTime
- If both relevantPeriod & relevantDateTime are null, <effectiveTime nullFlavor='UNK'/ 
 
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
