### PR TITLE
support multiple observations

### DIFF
--- a/lib/qrda-export/catIII-r2-1/_continuous_variable_value.mustache
+++ b/lib/qrda-export/catIII-r2-1/_continuous_variable_value.mustache
@@ -2,16 +2,16 @@
   <observation classCode="OBS" moodCode="EVN">
     <templateId root="2.16.840.1.113883.10.20.27.3.2"/>
     <code nullFlavor="OTH">
-      <originalText>Time Difference</originalText>
+      <originalText>Other</originalText>
     </code>
     <statusCode code="completed"/>
-    <value xsi:type="PQ" value="{{value}}" unit="min"/>
-    <methodCode code="MEDIAN" displayName="Median" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod"/>
+    <value xsi:type="REAL" value="{{value}}"/>
+    <methodCode code="{{method}}" displayName="{{method}}" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod"/>
     <reference typeCode="REFR">
       <!-- reference to the relevant measure observation in the eMeasure -->
       <externalObservation classCode="OBS" moodCode="EVN">
-        <id root="{{id}}"/>
+        <id root="{{hqmf_id}}"/>
       </externalObservation>
     </reference>
   </observation>
-</entryRelationship>  
+</entryRelationship>

--- a/lib/qrda-export/catIII-r2-1/_measure_data.mustache
+++ b/lib/qrda-export/catIII-r2-1/_measure_data.mustache
@@ -27,11 +27,9 @@
         {{> _supplemental_data}}
       {{/population_supplemental_data}}
     {{/supplemental_data}}
-    {{#msrpopl?}}
       {{#population_observation}}
         {{> _continuous_variable_value}}
       {{/population_observation}}
-    {{/msrpopl?}}
     <reference typeCode="REFR">
        <externalObservation classCode="OBS" moodCode="EVN">
           <id root="{{id}}"/>

--- a/lib/qrda-export/catIII-r2-1/_stratification.mustache
+++ b/lib/qrda-export/catIII-r2-1/_stratification.mustache
@@ -15,11 +15,9 @@
         <methodCode code="COUNT" displayName="Count" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod"/>
       </observation>
     </entryRelationship>
-    {{#msrpopl?}}
-      {{#stratification_observation}}
-        {{> _continuous_variable_value}}
-      {{/stratification_observation}}
-    {{/msrpopl?}}
+    {{#stratification_observation}}
+      {{> _continuous_variable_value}}
+    {{/stratification_observation}}
     <reference typeCode="REFR">
       <externalObservation classCode="OBS" moodCode="EVN">
         <id root="{{id}}"/>

--- a/lib/qrda-export/catIII-r2-1/qrda3_r21.rb
+++ b/lib/qrda-export/catIII-r2-1/qrda3_r21.rb
@@ -58,14 +58,11 @@ class Qrda3R21 < Mustache
   end
 
   def stratification_observation
-    observation = @measure_result_hash[self['measure_id']].aggregate_count.populations.find {|p| p.type == "OBSERV"}
-    stratification_observation = @measure_result_hash[self['measure_id']].aggregate_count.populations.find {|p| p.type == "OBSERV"}.stratifications.find {|s| s.id == self['id'] }
-    stratification_observation.id = observation.id
-    stratification_observation
+    self['observation']
   end
 
   def population_observation
-    @measure_result_hash[self['measure_id']].aggregate_count.populations.find {|p| p.type == "OBSERV"}
+    self['observation']
   end
 
   def supplemental_template_ids


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
