### PR TITLE
update cqm-validators dependency

### DIFF
--- a/cqm-reports.gemspec
+++ b/cqm-reports.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version = '3.1.3'
 
   s.add_dependency 'cqm-models', '~> 3.0.3'
-  s.add_dependency 'cqm-validators', '~> 3.0.0'
+  s.add_dependency 'cqm-validators', '~> 3.0'
 
   s.add_dependency 'mustache'
 


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
