### PR TITLE
Rails 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :development do
 end
 
 group :test do
-  gem 'cqm-models', '~> 3.0.3'
+  gem 'cqm-models', '~> 3.0'
   gem 'factory_girl', '~> 4.1.0'
   gem 'tailor', '~> 1.1.2'
   gem 'cane', '~> 2.3.0'

--- a/cqm-reports.gemspec
+++ b/cqm-reports.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.version = '3.1.3'
 
-  s.add_dependency 'cqm-models', '~> 3.0.3'
+  s.add_dependency 'cqm-models', '~> 3.0'
   s.add_dependency 'cqm-validators', '~> 3.0'
 
   s.add_dependency 'mustache'

--- a/cqm-reports.gemspec
+++ b/cqm-reports.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.authors = ["The MITRE Corporation"]
   s.license = 'Apache-2.0'
 
-  s.version = '3.1.3'
+  s.version = '3.1.4'
 
   s.add_dependency 'cqm-models', '~> 3.0'
   s.add_dependency 'cqm-validators', '~> 3.0'

--- a/lib/qrda-export/catI-r5/qrda_templates/template_partials/_reaction_observation.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/template_partials/_reaction_observation.mustache
@@ -4,6 +4,6 @@
       <id root="4adc1020-7b14-11db-9fe1-0800200c9a64" />
       <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" />
       <statusCode code="completed" />
-      {{> qrda_templates/template_partials/_data_element_codes_as_values}}
+      <value xsi:type="CD" {{> _code}}/>
     </observation>
   </entryRelationship>


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
