### PR TITLE
pass in flag for 2021 vs 2022 CMS Cat III IG

### DIFF
--- a/cqm-reports.gemspec
+++ b/cqm-reports.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.authors = ["The MITRE Corporation"]
   s.license = 'Apache-2.0'
 
-  s.version = '3.1.4'
+  s.version = '3.1.5'
 
   s.add_dependency 'cqm-models', '~> 3.0'
   s.add_dependency 'cqm-validators', '~> 3.0'

--- a/lib/qrda-export/catIII-r2-1/_header.mustache
+++ b/lib/qrda-export/catIII-r2-1/_header.mustache
@@ -3,8 +3,14 @@
 <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
 <!-- US Realm Header Template Id -->
 <templateId root="2.16.840.1.113883.10.20.27.1.1" extension="2017-06-01"/>
-<!-- QRDA Category III Report - CMS (V4) -->
+{{#ry2022_submission?}}
+<!-- QRDA Category III Report - CMS (V6) -->
+<templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2021-07-01"/>
+{{/ry2022_submission?}}
+{{^ry2022_submission?}}
+<!-- QRDA Category III Report - CMS (V5) -->
 <templateId root="2.16.840.1.113883.10.20.27.1.2" extension="2020-05-01"/>
+{{/ry2022_submission?}}
 <!-- This is the globally unique identifier for this QRDA document -->
 <id root="{{random_id}}"/>
 <!-- QRDA III document type code -->

--- a/lib/qrda-export/catIII-r2-1/qrda3_r21.rb
+++ b/lib/qrda-export/catIII-r2-1/qrda3_r21.rb
@@ -27,6 +27,7 @@ class Qrda3R21 < Mustache
     @performance_period_start = options[:start_time]
     @performance_period_end = options[:end_time]
     @submission_program = options[:submission_program]
+    @ry2022_submission = options[:ry2022_submission]
   end
 
   def agg_results(measure_id, cache_entries, population_sets)
@@ -85,6 +86,10 @@ class Qrda3R21 < Mustache
 
   def cpcplus?
     @submission_program == 'CPCPLUS'
+  end
+
+  def ry2022_submission?
+    @ry2022_submission
   end
 
   def payer_code?


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
