### PR TITLE
bump nokogiri in case of security vulnerability

### DIFF
--- a/cqm-reports.gemspec
+++ b/cqm-reports.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.authors = ["The MITRE Corporation"]
   s.license = 'Apache-2.0'
 
-  s.version = '3.1.6'
+  s.version = '3.1.7'
 
   s.add_dependency 'cqm-models', '~> 3.0'
   s.add_dependency 'cqm-validators', '~> 3.0'
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'erubis', '~> 2.7'
   s.add_dependency 'mongoid-tree', '> 2.0'
 
-  s.add_dependency 'nokogiri', '>= 1.8.5', '< 1.12.0'
+  s.add_dependency 'nokogiri', '>= 1.8.5', '< 1.13.0'
   s.add_dependency 'uuid', '~> 2.3'
 
   s.add_dependency 'zip-zip', '~> 0.3'


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
