### PR TITLE
allow for export and import of a result as a datetime

### DIFF
--- a/lib/qrda-export/helper/cat1_view_helper.rb
+++ b/lib/qrda-export/helper/cat1_view_helper.rb
@@ -56,19 +56,23 @@ module Qrda
         end
 
         def dose_quantity_value
-          return "<doseQuantity value=\"#{value_as_float}\" unit=\"#{self['unit']}\"/>" if self['unit']
+          return "<doseQuantity value=\"#{value_as_float}\" unit=\"#{self['unit']}\"/>" if self['unit'] && self['unit'] != ''
           "<doseQuantity value=\"#{value_as_float}\" />"
         end
 
         def result_value
           return "<value xsi:type=\"CD\" nullFlavor=\"UNK\"/>" unless self['result']
-
           result_string = if self['result'].is_a? Array
                             result_value_as_string(self['result'][0])
                           elsif self['result'].is_a? Hash
                             result_value_as_string(self['result'])
                           elsif self['result'].is_a? String
-                            "<value xsi:type=\"ST\">#{self['result']}</value>"
+                            begin
+                              DateTime.parse self['result']
+                              "<value xsi:type=\"TS\" #{value_or_null_flavor(self['result'])}/>"
+                            rescue
+                              "<value xsi:type=\"ST\">#{self['result']}</value>"
+                            end
                           elsif !self['result'].nil?
                             "<value xsi:type=\"PQ\" value=\"#{self['result']}\" unit=\"1\"/>"
                           end
@@ -79,7 +83,7 @@ module Qrda
           return "<value xsi:type=\"CD\" nullFlavor=\"UNK\"/>" unless result
           oid = result['system'] || result['codeSystem']
           return "<value xsi:type=\"CD\" code=\"#{result['code']}\" codeSystem=\"#{oid}\" codeSystemName=\"#{HQMF::Util::CodeSystemHelper.code_system_for(oid)}\"/>" if result['code']
-          return "<value xsi:type=\"PQ\" value=\"#{result['value']}\" unit=\"#{result['unit']}\"/>" if result['unit']
+          return "<value xsi:type=\"PQ\" value=\"#{result['value']}\" unit=\"#{result['unit']}\"/>" if result['unit'] && result['unit'] != ''
         end
 
         def authordatetime_or_dispenserid?

--- a/lib/qrda-import/base-importers/section_importer.rb
+++ b/lib/qrda-import/base-importers/section_importer.rb
@@ -193,6 +193,13 @@ module QRDA
         return unless value_element && !value_element['nullFlavor']
         value = value_element['value']
         if value.present?
+          if ['TS'].include? value_element.at_xpath("@xsi:type")&.value
+            begin
+              return DateTime.parse(value_element['value'])
+            rescue
+              return nil
+            end
+          end
           return value.strip.to_f if (value_element['unit'] == "1" || value_element['unit'].nil?)
 
           return QDM::Quantity.new(value.strip.to_f, value_element['unit'])


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
