### PR TITLE
Add warning for translation code (#140) (#143)

### DIFF
--- a/lib/qrda-import/base-importers/section_importer.rb
+++ b/lib/qrda-import/base-importers/section_importer.rb
@@ -77,7 +77,13 @@ module QRDA
           code_list << code_if_present(code_element)
           translations = code_element.xpath('cda:translation')
           translations.each do |translation|
-            code_list << code_if_present(translation)
+            translation_code = code_if_present(translation)
+            next unless translation_code
+
+            code_list << translation_code
+            root_code_string = "#{code_list[0].system}:#{code_list[0].code}"
+            @warnings << ValidationError.new(message: "Translation code #{translation_code.system}:#{translation_code.code} may not be used for eCQM calculation by a receiving system.  Ensure that the root code #{root_code_string} is from an eCQM valueset.",
+                                             location: coded_element.path)
           end
         end
         code_list.compact


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
