### PR TITLE
In R5.2 Device Applied performer is singular not an array

### DIFF
--- a/lib/qrda-import/data-element-importers/device_applied_r52_importer.rb
+++ b/lib/qrda-import/data-element-importers/device_applied_r52_importer.rb
@@ -18,7 +18,7 @@ module QRDA
         device_applied.anatomicalLocationSite = code_if_present(entry_element.at_xpath(@anatomical_location_site_xpath))
         device_applied.reason = extract_reason(entry_element)
         entity = extract_entity(entry_element, "./cda:participant[@typeCode='PRF']")
-        device_applied.performer.concat(entity) if entity
+        device_applied.performer = entity.first if entity
         device_applied
       end
 


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
