### PR TITLE
Added Missing HICN number during QRDA 1 Export

### DIFF
--- a/lib/qrda-export/catI-r5/qrda1_r5.rb
+++ b/lib/qrda-export/catI-r5/qrda1_r5.rb
@@ -20,6 +20,7 @@ class Qrda1R5 < Mustache
     @performance_period_end = options[:end_time]
     @submission_program = options[:submission_program]
     @medicare_beneficiary_identifier = options[:medicare_beneficiary_identifier]
+    @hicn = options[:hicn]
   end
 
   def patient_addresses

--- a/lib/qrda-export/catI-r5/qrda_header/_record_target.mustache
+++ b/lib/qrda-export/catI-r5/qrda_header/_record_target.mustache
@@ -4,6 +4,9 @@
     {{#medicare_beneficiary_identifier}}
       <id extension="{{medicare_beneficiary_identifier}}" root="2.16.840.1.113883.4.927" />
     {{/medicare_beneficiary_identifier}}
+    {{#hicn}}
+      <id extension="{{hicn}}" root="2.16.840.1.113883.4.572" />
+    {{/hicn}}
     {{#patient_addresses}}
       <addr use="{{use}}">
         {{#street}}

--- a/lib/qrda-export/helper/view_helper.rb
+++ b/lib/qrda-export/helper/view_helper.rb
@@ -26,6 +26,10 @@ module Qrda
         def medicare_beneficiary_identifier
           @medicare_beneficiary_identifier
         end
+
+        def hicn
+          @hicn
+        end
       end
     end
   end


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
