### PR TITLE
Support HTML views with results that are Date and String values

### DIFF
--- a/lib/html-export/qdm-patient/qdm_patient.rb
+++ b/lib/html-export/qdm-patient/qdm_patient.rb
@@ -127,7 +127,13 @@ class QdmPatient < Mustache
     return unit_string if self['value']
     return code_code_system_string if self['code']
 
-    trimed_value(self['result'])
+    # Checks to see if the result is a DateTime value, String, or Numeric
+    begin
+      DateTime.parse(self['result'])
+    rescue ArgumentError, TypeError
+      # If the value is not numeric, just print out the result
+      self['result'].is_a?(Numeric) ? trimed_value(self['result']) : self['result']
+    end
   end
 
   def nested_code_string


### PR DESCRIPTION
Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
