### PR TITLE
status code for dx should mirror what is being reported in the preval…

### DIFF
--- a/lib/qrda-export/catI-r5/qrda_templates/diagnosis.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/diagnosis.mustache
@@ -34,9 +34,6 @@
         {{/completed_prevalence_period}}
         {{{prevalence_period}}}
         {{/prevalencePeriod}}
-        {{#prevalencePeriod}}
-        {{{prevalence_period}}}
-        {{/prevalencePeriod}}
         <!-- QDM Attribute: Code -->
         {{> qrda_templates/template_partials/_data_element_codes_as_values}}
         {{#anatomicalLocationSite}}

--- a/lib/qrda-export/catI-r5/qrda_templates/diagnosis.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/diagnosis.mustache
@@ -25,7 +25,15 @@
         <code code="29308-4" codeSystem="2.16.840.1.113883.6.1">
           <translation code="282291009" codeSystem="2.16.840.1.113883.6.96"/>
         </code>
+        {{#prevalencePeriod}}
+        {{#completed_prevalence_period}}
         <statusCode code="completed" />
+        {{/completed_prevalence_period}}
+        {{^completed_prevalence_period}}
+        <statusCode code="active" />
+        {{/completed_prevalence_period}}
+        {{{prevalence_period}}}
+        {{/prevalencePeriod}}
         {{#prevalencePeriod}}
         {{{prevalence_period}}}
         {{/prevalencePeriod}}


### PR DESCRIPTION
…encePeriod

Pull requests into cqm-parsers require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
