### PR TITLE
Remove reference to Cypress in HTML output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,8 @@ jobs:
       run: bundle exec rake test
     - name: Run rubocop
       run: rubocop
+    - name: Upload code coverage to codecov.io
+      uses: codecov/codecov-action@v3
+      with:
+        directory: coverage
+        name: codecov-integration

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :test do
   gem 'cane', '~> 2.3.0'
   gem 'codecov'
   gem 'simplecov', :require => false
+  gem 'simplecov-cobertura'
   gem 'webmock'
   gem 'minitest', '~> 5.3'
   gem 'minitest-reporters'

--- a/lib/html-export/qdm-patient/qdm_patient.mustache
+++ b/lib/html-export/qdm-patient/qdm_patient.mustache
@@ -3,7 +3,7 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     {{#patient}}
-    <title>Cypress Certification Patient Test Record: {{given_name}} {{familyName}}</title>
+    <title>Patient Test Record: {{given_name}} {{familyName}}</title>
     {{/patient}}
     {{#include_style?}}
       {{> _header_css}}
@@ -11,7 +11,7 @@
   </head>
   <body>
     {{#patient}}
-    <h1 class="h1center">Cypress Certification Patient Test Record: {{given_name}} {{familyName}}</h1>
+    <h1 class="h1center">Patient Test Record: {{given_name}} {{familyName}}</h1>
     <div class="div-table">
       <div class="div-table-body">
         <div class="div-head-row patient_narr_tr panel panel-default patient-details">
@@ -36,7 +36,7 @@
           <div class="div-table-head patient_narr_th panel-heading"><span class="td_label">Insurance Providers</span></div>
           <div class="div-table-head">{{{payer}}}{{#demographic_code_description}}payer{{/demographic_code_description}}</div>
           <div class="div-table-head patient_narr_th panel-heading"><span class="td_label">Patient IDs</span></div>
-          <div class="div-table-head">{{{mrn}}} Cypress</div>
+          <div class="div-table-head">{{{mrn}}}</div>
         </div>
         <div class="div-head-row patient_narr_tr panel panel-default patient-details">
           <div class="div-table-head patient_narr_th panel-heading"><span class="td_label">Address</span></div>

--- a/test/simplecov_init.rb
+++ b/test/simplecov_init.rb
@@ -5,4 +5,9 @@ SimpleCov.start do
   track_files 'lib/**/*.rb'
 end
 
-SimpleCov.formatter = SimpleCov::Formatter::Codecov
+if ENV['CI'] == 'true'
+  require 'simplecov-cobertura'
+  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
+else
+  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+end


### PR DESCRIPTION
Pull requests into cqm-reports require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
