### PR TITLE
Remove other references to Cypress in QRDA files.  Allow for an input…

### DIFF
--- a/lib/qrda-export/catI-r5/qrda1_r5.rb
+++ b/lib/qrda-export/catI-r5/qrda1_r5.rb
@@ -22,6 +22,11 @@ class Qrda1R5 < Mustache
     @submission_program = options[:submission_program]
     @medicare_beneficiary_identifier = options[:medicare_beneficiary_identifier]
     @hicn = options[:hicn]
+    @authoring_system = options[:authoring_system]
+  end
+
+  def authoring_system
+    @authoring_system || 'TestSystem'
   end
 
   def patient_addresses

--- a/lib/qrda-export/catI-r5/qrda_header/_author.mustache
+++ b/lib/qrda-export/catI-r5/qrda_header/_author.mustache
@@ -19,8 +19,8 @@
     </addr>
     <telecom use="WP" value="tel:(781)271-3000"/>
     <assignedAuthoringDevice>
-      <manufacturerModelName>Cypress</manufacturerModelName>
-      <softwareName>Cypress</softwareName>
+      <manufacturerModelName>{{authoring_system}}</manufacturerModelName>
+      <softwareName>{{authoring_system}}</softwareName>
     </assignedAuthoringDevice>
   </assignedAuthor>
 </author>

--- a/lib/qrda-export/catI-r5/qrda_header/_custodian.mustache
+++ b/lib/qrda-export/catI-r5/qrda_header/_custodian.mustache
@@ -8,7 +8,7 @@
       {{^provider_ccn}}
         <id extension="800890" root="2.16.840.1.113883.4.336"/>
       {{/provider_ccn}}
-      <name>Cypress Test Deck</name>
+      <name>{{authoring_system}} Test Deck</name>
       <telecom use="WP" value="tel:(781)271-3000"/>
       {{#addresses}}
       <addr use="HP">
@@ -28,7 +28,7 @@
   <assignedCustodian>
     <representedCustodianOrganization>
       <id extension="800890" root="2.16.840.1.113883.4.336"/>
-      <name>Cypress Test Deck</name>
+      <name>{{authoring_system}} Test Deck</name>
       <telecom use="WP" value="tel:(781)271-3000"/>
       <addr>
         <streetAddressLine>202 Burlington Rd.</streetAddressLine>

--- a/lib/qrda-export/catI-r5/qrda_header/_legal_authenticator.mustache
+++ b/lib/qrda-export/catI-r5/qrda_header/_legal_authenticator.mustache
@@ -19,7 +19,7 @@
     </assignedPerson>
     <representedOrganization>
       <id root="2.16.840.1.113883.19.5"/>
-      <name>Cypress</name>
+      <name>{{authoring_system}}</name>
     </representedOrganization>
   </assignedEntity>
 </legalAuthenticator>

--- a/lib/qrda-export/catI-r5/qrda_templates/template_partials/_facility_location.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/template_partials/_facility_location.mustache
@@ -18,7 +18,7 @@
     </addr>
     <telecom use="WP" value="tel:(781)271-3000"/>
     <playingEntity classCode="PLC">
-      <name>Cypress Test Deck</name>
+      <name>{{authoring_system}} Test Deck</name>
     </playingEntity>
   </participantRole>
 </participant>

--- a/lib/qrda-export/catIII/qrda3.rb
+++ b/lib/qrda-export/catIII/qrda3.rb
@@ -29,6 +29,7 @@ class Qrda3 < Mustache
     @submission_program = options[:submission_program]
     @ry2022_submission = options[:ry2022_submission]
     @ry2025_submission = options[:ry2025_submission]
+    @authoring_system = options[:authoring_system]
   end
 
   def agg_results(measure_id, cache_entries, population_sets)
@@ -95,6 +96,10 @@ class Qrda3 < Mustache
 
   def ry2025_submission?
     @ry2025_submission
+  end
+
+  def authoring_system
+    @authoring_system || 'TestSystem'
   end
 
   def payer_code?

--- a/lib/qrda-export/catIII/qrda_header/_author.mustache
+++ b/lib/qrda-export/catIII/qrda_header/_author.mustache
@@ -1,7 +1,7 @@
 <author>
   <time value="{{current_time}}"/>
   <assignedAuthor>
-    <!-- id extension="Cypress" root="2.16.840.1.113883.19.5"/ -->
+    <!-- id extension="{{authoring_system}}" root="2.16.840.1.113883.19.5"/ -->
     <!-- NPI -->
     <id extension="1982671962" root="2.16.840.1.113883.4.6"/>
     <addr>
@@ -13,8 +13,8 @@
     </addr>
     <telecom use="WP" value="tel:(781)271-3000"/>
     <assignedAuthoringDevice>
-      <manufacturerModelName>Cypress</manufacturerModelName>
-      <softwareName>Cypress</softwareName>
+      <manufacturerModelName>{{authoring_system}}</manufacturerModelName>
+      <softwareName>{{authoring_system}}</softwareName>
     </assignedAuthoringDevice>
     <representedOrganization>
       <!-- The organization id is optional, but the name is required -->

--- a/lib/qrda-export/catIII/qrda_header/_custodian.mustache
+++ b/lib/qrda-export/catIII/qrda_header/_custodian.mustache
@@ -3,7 +3,7 @@
     <representedCustodianOrganization>
       <!-- HQR Only -->
       <id extension="800890" root="2.16.840.1.113883.4.336"/>
-      <name>Cypress Test Deck</name>
+      <name>{{authoring_system}} Test Deck</name>
       <telecom use="WP" value="tel:(781)271-3000"/>
       <addr>
         <streetAddressLine>202 Burlington Rd.</streetAddressLine>

--- a/lib/qrda-export/catIII/qrda_header/_legal_authenticator.mustache
+++ b/lib/qrda-export/catIII/qrda_header/_legal_authenticator.mustache
@@ -19,7 +19,7 @@
     </assignedPerson>
     <representedOrganization>
       <id root="2.16.840.1.113883.19.5"/>
-      <name>Cypress</name>
+      <name>{{authoring_system}}</name>
     </representedOrganization>
   </assignedEntity>
 </legalAuthenticator>


### PR DESCRIPTION
… to provide your own name.

Pull requests into cqm-reports require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
