### PR TITLE
nest "other" check in case statement

### DIFF
--- a/lib/qrda-export/catIII/qrda3.rb
+++ b/lib/qrda-export/catIII/qrda3.rb
@@ -69,17 +69,18 @@ class Qrda3 < Mustache
   end
 
   def supplemental_template_ids
-    if other_gender_code?
-      return [{ tid: '2.16.840.1.113883.10.20.27.3.6', extension: '2016-09-01' },
-              { tid: '2.16.840.1.113883.10.20.27.3.21', extension: '2025-05-01' }]
-    end
     case self['type']
     when 'RACE'
       [{ tid: '2.16.840.1.113883.10.20.27.3.8', extension: '2016-09-01' }]
     when 'ETHNICITY'
       [{ tid: '2.16.840.1.113883.10.20.27.3.7', extension: '2016-09-01' }]
     when 'SEX'
-      [{ tid: '2.16.840.1.113883.10.20.27.3.6', extension: '2016-09-01' }]
+      if other_gender_code?
+        [{ tid: '2.16.840.1.113883.10.20.27.3.6', extension: '2016-09-01' },
+         { tid: '2.16.840.1.113883.10.20.27.3.21', extension: '2025-05-01' }]
+      else
+        [{ tid: '2.16.840.1.113883.10.20.27.3.6', extension: '2016-09-01' }]
+      end
     when 'PAYER'
       [{ tid: '2.16.840.1.113883.10.20.27.3.9', extension: '2016-02-01' },
        { tid: '2.16.840.1.113883.10.20.27.3.18', extension: '2018-05-01' }]


### PR DESCRIPTION
Pull requests into cqm-reports require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
