### PR TITLE
Mood codes in the relatedTo template are dependent on the element bei…

### DIFF
--- a/lib/qrda-export/catI-r5/qrda_templates/template_partials/_related_to.mustache
+++ b/lib/qrda-export/catI-r5/qrda_templates/template_partials/_related_to.mustache
@@ -1,6 +1,6 @@
 <sdtc:inFulfillmentOf1 typeCode="FLFS">
   <sdtc:templateId root="2.16.840.1.113883.10.20.24.3.150" extension="2017-08-01"/>
-  <sdtc:actReference classCode="ACT" moodCode="EVN">
+  <sdtc:actReference classCode="ACT" moodCode="{{{mood_for_id}}}">
     <sdtc:id root="1.3.6.1.4.1.115" extension="{{{.}}}"/>
   </sdtc:actReference>
 </sdtc:inFulfillmentOf1>

--- a/lib/qrda-export/helper/cat1_view_helper.rb
+++ b/lib/qrda-export/helper/cat1_view_helper.rb
@@ -2,7 +2,6 @@ module Qrda
   module Export
     module Helper
       module Cat1ViewHelper
-
         def mood_for_id
           related_id = self['relatedTo']&.first
           # If there isn't a relatedTo id, return a default mood code
@@ -13,15 +12,9 @@ module Qrda
 
           # Find a corresponding mood code for the qdmStatus.  Default to EVN if none found
           {
-            'active' => 'EVN',
-            'administered' => 'EVN',
-            'discharge' => 'RQO',
-            'dispensed' => 'EVN',
-            'expired' => 'EVN',
-            'intolerance' => 'EVN',
-            'order' => 'RQO',
-            'payer' => 'EVN',
-            'performed' => 'EVN',
+            'active' => 'EVN', 'administered' => 'EVN', 'dispensed' => 'EVN', 'expired' => 'EVN',
+            'intolerance' => 'EVN', 'payer' => 'EVN', 'performed' => 'EVN',
+            'discharge' => 'RQO', 'order' => 'RQO',
             'recommended' => 'INT'
           }.fetch(status, 'EVN')
         end

--- a/lib/qrda-export/helper/cat1_view_helper.rb
+++ b/lib/qrda-export/helper/cat1_view_helper.rb
@@ -2,6 +2,30 @@ module Qrda
   module Export
     module Helper
       module Cat1ViewHelper
+
+        def mood_for_id
+          related_id = self['relatedTo']&.first
+          # If there isn't a relatedTo id, return a default mood code
+          return 'EVN' if related_id.blank?
+
+          # Find the qdmStatus for the dataElement for the relatedTo id
+          status = @qdmPatient.dataElements.find { |de| de._id.to_s == related_id }&.qdmStatus
+
+          # Find a corresponding mood code for the qdmStatus.  Default to EVN if none found
+          {
+            'active' => 'EVN',
+            'administered' => 'EVN',
+            'discharge' => 'RQO',
+            'dispensed' => 'EVN',
+            'expired' => 'EVN',
+            'intolerance' => 'EVN',
+            'order' => 'RQO',
+            'payer' => 'EVN',
+            'performed' => 'EVN',
+            'recommended' => 'INT'
+          }.fetch(status, 'EVN')
+        end
+
         def negation_ind
           self[:negationRationale].nil? ? "" : "negationInd=\"true\""
         end


### PR DESCRIPTION
…ng referenced

Pull requests into cqm-reports require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
