### PR TITLE
allow for the import of a nullFlavored payer

### DIFF
--- a/lib/qrda-import/data-element-importers/patient_characteristic_payer_importer.rb
+++ b/lib/qrda-import/data-element-importers/patient_characteristic_payer_importer.rb
@@ -11,6 +11,16 @@ module QRDA
 
       def create_entry(entry_element, nrh = NarrativeReferenceHandler.new)
         patient_characteristic_payer = super
+        return patient_characteristic_payer unless patient_characteristic_payer.dataElementCodes.blank?
+
+        null_flavor = entry_element.at_xpath(code_xpath)&.[]('nullFlavor')
+
+        if null_flavor
+          patient_characteristic_payer.dataElementCodes = [
+            { code: null_flavor, system: 'NA' }
+          ]
+        end
+
         patient_characteristic_payer
       end
 


### PR DESCRIPTION
Pull requests into cqm-reports require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
