### PR TITLE
catch the case when a data element does not have a qdmStatus

### DIFF
--- a/cqm-reports.gemspec
+++ b/cqm-reports.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.authors = ["The MITRE Corporation"]
   s.license = 'Apache-2.0'
 
-  s.version = '4.1.7'
+  s.version = '4.1.8'
 
   s.add_dependency 'cqm-models', '~> 4.0'
   s.add_dependency 'cqm-validators', '~> 4.0'

--- a/lib/qrda-export/helper/cat1_view_helper.rb
+++ b/lib/qrda-export/helper/cat1_view_helper.rb
@@ -8,7 +8,7 @@ module Qrda
           return 'EVN' if related_id.blank?
 
           data_element = @qdmPatient.dataElements.find { |de| de._id.to_s == related_id }
-          return 'EVN' unless data_element&.respond_to?(:qdmStatus)
+          return 'EVN' unless data_element.respond_to?(:qdmStatus)
 
           # Find a corresponding mood code for the qdmStatus.  Default to EVN if none found
           {

--- a/lib/qrda-export/helper/cat1_view_helper.rb
+++ b/lib/qrda-export/helper/cat1_view_helper.rb
@@ -7,8 +7,8 @@ module Qrda
           # If there isn't a relatedTo id, return a default mood code
           return 'EVN' if related_id.blank?
 
-          # Find the qdmStatus for the dataElement for the relatedTo id
-          status = @qdmPatient.dataElements.find { |de| de._id.to_s == related_id }&.qdmStatus
+          data_element = @qdmPatient.dataElements.find { |de| de._id.to_s == related_id }
+          return 'EVN' unless data_element && data_element.respond_to?(:qdmStatus)
 
           # Find a corresponding mood code for the qdmStatus.  Default to EVN if none found
           {
@@ -16,7 +16,7 @@ module Qrda
             'intolerance' => 'EVN', 'payer' => 'EVN', 'performed' => 'EVN',
             'discharge' => 'RQO', 'order' => 'RQO',
             'recommended' => 'INT'
-          }.fetch(status, 'EVN')
+          }.fetch(data_element.qdmStatus, 'EVN')
         end
 
         def negation_ind

--- a/lib/qrda-export/helper/cat1_view_helper.rb
+++ b/lib/qrda-export/helper/cat1_view_helper.rb
@@ -8,7 +8,7 @@ module Qrda
           return 'EVN' if related_id.blank?
 
           data_element = @qdmPatient.dataElements.find { |de| de._id.to_s == related_id }
-          return 'EVN' unless data_element && data_element.respond_to?(:qdmStatus)
+          return 'EVN' unless data_element&.respond_to?(:qdmStatus)
 
           # Find a corresponding mood code for the qdmStatus.  Default to EVN if none found
           {


### PR DESCRIPTION
Pull requests into cqm-reports require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
